### PR TITLE
Bleve search syntax assistance by local Ollama model

### DIFF
--- a/backend/pkg/server/handlers/ai_query.go
+++ b/backend/pkg/server/handlers/ai_query.go
@@ -1,0 +1,351 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"logsonic/pkg/types"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// AIQueryRequest defines the structure sent to the Ollama API
+type AIQueryRequest struct {
+	Columns []string `json:"columns"`
+	Query   string   `json:"query"`
+}
+
+// AIQueryResponse defines the expected response structure from Ollama 
+type AIQueryResponse struct {
+	Query      string  `json:"query"`
+	Confidence float64 `json:"confidence"`
+}
+
+// AIQueryAPIResponse defines the API response we send back to the client
+type AIQueryAPIResponse struct {
+	Query           string   `json:"query"`
+	Confidence      float64  `json:"confidence"`
+	AvailableModels []string `json:"available_models"`
+	ModelUsed       string   `json:"model_used"`
+	Success         bool     `json:"success"`
+	Error           string   `json:"error,omitempty"`
+}
+
+// HandleQueryTranslation handles translation from natural language to Logsonic query syntax
+// @Summary Translate natural language to Logsonic query
+// @Description Converts natural language description into Logsonic query syntax using AI
+// @ID translate-query
+// @Accept json
+// @Produce json
+// @Param request body handlers.AIQueryRequest true "Natural language query and column information"
+// @Success 200 {object} handlers.AIQueryAPIResponse "Translated query with confidence score"
+// @Failure 400 {object} types.ErrorResponse "Bad request due to invalid parameters"
+// @Failure 500 {object} types.ErrorResponse "Internal server error"
+// @Router /api/v1/ai/translate-query [post]
+func (h *Services) HandleQueryTranslation(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(types.ErrorResponse{
+			Status: "error",
+			Error:  "Method not allowed",
+			Code:   "METHOD_NOT_ALLOWED",
+		})
+		return
+	}
+
+	// Parse request body
+	var request AIQueryRequest
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(types.ErrorResponse{
+			Status:  "error",
+			Error:   "Invalid request body",
+			Code:    "INVALID_PARAMETER",
+			Details: err.Error(),
+		})
+		return
+	}
+
+	
+	// Validate request
+	if request.Query == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(types.ErrorResponse{
+			Status:  "error",
+			Error:   "Empty query",
+			Code:    "INVALID_PARAMETER",
+			Details: "Query cannot be empty",
+		})
+		return
+	}
+
+	// Try to get available columns from storage if none provided
+	if len(request.Columns) == 0 {
+		// Use default columns - we don't have a direct API to get all columns
+		request.Columns = []string{"timestamp", "message"}
+	}
+
+	// Set ollama endpoint - default to localhost
+	// TODO: Make this configurable
+	ollamaEndpoint := "http://localhost:11434/api/generate"
+	
+	// Get available models to find the right Logsonic model
+	availableModels := []string{}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err == nil {
+		defer resp.Body.Close()
+		
+		var tagsResponse struct {
+			Models []struct {
+				Name string `json:"name"`
+			} `json:"models"`
+		}
+		
+		if err := json.NewDecoder(resp.Body).Decode(&tagsResponse); err == nil {
+			for _, model := range tagsResponse.Models {
+				availableModels = append(availableModels, model.Name)
+			}
+		}
+	}
+	
+	// Find the appropriate Logsonic model to use
+	modelName := findLogsonicModel(availableModels)
+	
+	// Call the Ollama API with the selected model
+	response, err := callOllamaAPI(ollamaEndpoint, modelName, request)
+	
+	// If Ollama fails and OpenAI is configured, we could fall back to it here
+	// For now, just return the error
+	
+	if err != nil {
+		fmt.Printf("[AI Query] Error translating query: %s\n", err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(types.ErrorResponse{
+			Status:  "error",
+			Error:   "AI model error",
+			Code:    "AI_MODEL_ERROR",
+			Details: err.Error(),
+		})
+		return
+	}
+
+	// Return the response
+	apiResponse := AIQueryAPIResponse{
+		Query:           response.Query,
+		Confidence:      response.Confidence,
+		AvailableModels: availableModels,
+		ModelUsed:       modelName,
+		Success:         true,
+	}
+
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(apiResponse)
+}
+
+// OllamaRequest is the structure for requests to Ollama API
+type OllamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+// OllamaResponse is the structure for responses from Ollama API
+type OllamaResponse struct {
+	Model     string `json:"model"`
+	Response  string `json:"response"`
+	CreatedAt string `json:"created_at"`
+}
+
+// Function to call the Ollama API
+func callOllamaAPI(endpoint string, model string, request AIQueryRequest) (AIQueryResponse, error) {
+	// Create JSON string for the prompt
+	promptData, err := json.Marshal(request)
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create Ollama request
+	ollamaRequest := OllamaRequest{
+		Model:  model,
+		Prompt: string(promptData),
+		Stream: false, // Disable streaming to get complete response at once
+	}
+
+	requestBody, err := json.Marshal(ollamaRequest)
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to marshal Ollama request: %w", err)
+	}
+
+
+	// Create HTTP request
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	
+	resp, err := client.Post(endpoint, "application/json", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to call Ollama API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to read Ollama response: %w", err)
+	}
+
+
+	// Parse Ollama response
+	var ollamaResp OllamaResponse
+	err = json.Unmarshal(respBody, &ollamaResp)
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to parse Ollama response: %w", err)
+	}
+
+	// Extract JSON from the text response
+	jsonStr := ollamaResp.Response
+	// Clean up JSON - sometimes Ollama adds extra text before/after the JSON
+	jsonStr = strings.TrimSpace(jsonStr)
+	
+	// Try to find JSON content between braces
+	startIndex := strings.Index(jsonStr, "{")
+	endIndex := strings.LastIndex(jsonStr, "}")
+	
+	if startIndex >= 0 && endIndex > startIndex {
+		jsonStr = jsonStr[startIndex : endIndex+1]
+	}
+	
+	// Parse the JSON response
+	var aiResponse AIQueryResponse
+	err = json.Unmarshal([]byte(jsonStr), &aiResponse)
+	if err != nil {
+		return AIQueryResponse{}, fmt.Errorf("failed to parse AI response: %w", err)
+	}
+
+	return aiResponse, nil
+}
+
+// Function to check if the Ollama service is running
+func IsOllamaRunning() bool {
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	
+	return resp.StatusCode == http.StatusOK
+}
+
+// HandleCheckAIStatus checks if AI services (Ollama) are available
+// @Summary Check AI service status
+// @Description Checks if the Ollama service is running and the required models are available
+// @ID check-ai-status
+// @Produce json
+// @Success 200 {object} map[string]interface{} "AI service status information"
+// @Router /api/v1/ai/status [get]
+func (h *Services) HandleCheckAIStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(types.ErrorResponse{
+			Status: "error",
+			Error:  "Method not allowed",
+			Code:   "METHOD_NOT_ALLOWED",
+		})
+		return
+	}
+
+	// Check if Ollama is running
+	isOllamaRunning := IsOllamaRunning()
+	
+	// Prepare response
+	response := map[string]interface{}{
+		"ollama_running": isOllamaRunning,
+		"models_available": []string{},
+	}
+	
+	// If Ollama is running, check available models
+	if isOllamaRunning {
+		client := &http.Client{
+			Timeout: 5 * time.Second,
+		}
+		
+		resp, err := client.Get("http://localhost:11434/api/tags")
+		if err == nil {
+			defer resp.Body.Close()
+			
+			var tagsResponse struct {
+				Models []struct {
+					Name string `json:"name"`
+				} `json:"models"`
+			}
+			
+			if err := json.NewDecoder(resp.Body).Decode(&tagsResponse); err == nil {
+				modelNames := []string{}
+				logsonicModels := []string{}
+				
+				for _, model := range tagsResponse.Models {
+					modelNames = append(modelNames, model.Name)
+					// Check if this is a Logsonic model (contains "logsonic" in the name)
+					if strings.Contains(strings.ToLower(model.Name), "logsonic") {
+						logsonicModels = append(logsonicModels, model.Name)
+					}
+				}
+				
+				response["models_available"] = modelNames
+				
+				// Log if any Logsonic models are detected
+				if len(logsonicModels) > 0 {
+					fmt.Printf("[AI Status] Logsonic models detected: %s\n", strings.Join(logsonicModels, ", "))
+				} else {
+					fmt.Println("[AI Status] Ollama is running but no Logsonic models are available")
+				}
+			}
+		}
+	} else {
+		fmt.Println("[AI Status] Ollama service is not running")
+	}
+	
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+// Set appropriate Ollama model name based on available models
+func findLogsonicModel(availableModels []string) string {
+	// Priority order: "logsonic", "logsonic:latest", "logsonic-search", any model with "logsonic" in the name
+	if len(availableModels) == 0 {
+		return "logsonic" // Default if no models available
+	}
+	
+	// First try exact matches in order of preference
+	preferredModels := []string{"logsonic", "logsonic:latest"}
+	for _, preferred := range preferredModels {
+		for _, available := range availableModels {
+			if available == preferred {
+				return available
+			}
+		}
+	}
+	
+	// Then try partial matches
+	for _, available := range availableModels {
+		if strings.Contains(strings.ToLower(available), "logsonic") {
+			return available
+		}
+	}
+	
+	// Fallback to default
+	return "logsonic"
+} 

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -235,6 +235,12 @@ func NewServer(cfg Config) (*Server, error) {
 			r.Post("/log-events", h.HandleGetCloudWatchLogEvents)
 		})
 
+		// Add AI endpoints
+		r.Route("/ai", func(r chi.Router) {
+			r.Get("/status", h.HandleCheckAIStatus)
+			r.Post("/translate-query", h.HandleQueryTranslation)
+		})
+
 	})
 
 	return &Server{

--- a/frontend/src/components/Home/AIQueryDialog.tsx
+++ b/frontend/src/components/Home/AIQueryDialog.tsx
@@ -1,0 +1,229 @@
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { translateQuery } from "@/services/aiService";
+import { useLogResultStore } from "@/stores/useLogResultStore";
+import { useSearchQueryParamsStore } from "@/stores/useSearchQueryParams";
+import { AlertCircle, Check, Copy, Sparkles } from "lucide-react";
+import { useCallback, useState } from "react";
+
+const EXAMPLE_QUERIES = [
+  "all logs with error or warning",
+  "api service",
+  "pid more than 2000",
+  "response time more than 1000ms",
+  "'connection timeout' errors",
+  "hostname is Quantcast and service is api",
+  "message like '%error%'",
+  
+];
+
+// Styled code example component, similar to QueryHelperPopover
+function CodeExample({ content, confidence }: { content: string; confidence?: number }) {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="bg-gray-50 border border-gray-200 p-3 rounded-lg text-sm relative group hover:border-gray-300 transition-colors min-h-[120px]">
+      <div className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <Button 
+          variant="ghost" 
+          size="icon" 
+          className="h-6 w-6 bg-white hover:bg-gray-50 rounded-md shadow-sm border border-gray-200" 
+          onClick={copyToClipboard}
+          title="Copy to clipboard"
+        >
+          {copied ? <Check size={14} className="text-green-600" /> : <Copy size={14} />}
+        </Button>
+      </div>
+      {confidence !== undefined && (
+        <div className="absolute left-3 top-3 text-xs text-gray-500">
+          Confidence: {Math.round(confidence * 100)}%
+        </div>
+      )}
+      <code className="text-gray-800 block mt-6 whitespace-pre-wrap">{content}</code>
+    </div>
+  );
+}
+
+interface AIQueryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onQueryApplied?: (query: string) => void;
+}
+
+export function AIQueryDialog({ open, onOpenChange, onQueryApplied }: AIQueryDialogProps) {
+  const [inputQuery, setInputQuery] = useState("");
+  const [translatedQuery, setTranslatedQuery] = useState("");
+  const [confidence, setConfidence] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const store = useSearchQueryParamsStore();
+  const logResultStore = useLogResultStore();
+
+  const handleExampleClick = useCallback((example: string) => {
+    setInputQuery(example);
+    setErrorMessage("");
+  }, []);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputQuery(e.target.value);
+    setErrorMessage("");
+  }, []);
+
+  const handleTranslate = useCallback(async () => {
+    if (!inputQuery.trim()) {
+      setErrorMessage("Please enter a query to translate");
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage("");
+    
+    try {
+      // Get the available columns from the store or use defaults
+      const columns = store.availableColumns.length > 0 
+        ? store.availableColumns 
+        : ["timestamp", "message", "level", "service", "host"];
+
+      const response = await translateQuery({
+        columns,
+        query: inputQuery,
+      });
+
+      setTranslatedQuery(response.query);
+      setConfidence(response.confidence);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to translate query");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [inputQuery, store.availableColumns]);
+
+  // Handle Enter key press in the input field
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !isLoading && inputQuery.trim()) {
+      e.preventDefault();
+      handleTranslate();
+    }
+  }, [handleTranslate, inputQuery, isLoading]);
+
+  const handleApplyQuery = useCallback(() => {
+    if (translatedQuery) {
+      // Trim the query to remove any leading/trailing whitespace
+      const trimmedQuery = translatedQuery.trim();
+      
+      // Apply the trimmed query
+      store.setSearchQuery(trimmedQuery);
+      
+      // Call the callback to update the search field in the parent component
+      if (onQueryApplied) {
+        onQueryApplied(trimmedQuery);
+      }
+      
+      // Close the dialog
+      onOpenChange(false);
+    }
+  }, [translatedQuery, store, onOpenChange, onQueryApplied]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[800px] p-0 border-0 shadow-2xl bg-white rounded-xl overflow-hidden">
+        <div className="p-6 border-b bg-gradient-to-r from-blue-50 to-white">
+          <div className="flex justify-between items-start">
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold text-gray-900 flex items-center">
+                <Sparkles className="h-5 w-5 mr-2 text-yellow-500" />
+                AI Query Builder
+              </h2>
+              <p className="text-sm text-gray-600">
+                Describe what you're looking for in plain English and we'll convert it to Logsonic search query.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          <div className="">
+            <div>
+              <label className="text-md font-medium leading-none mb-4 block text-gray-700">Example Queries</label>
+              <div className="flex flex-wrap gap-2 mb-3">
+                {EXAMPLE_QUERIES.map((example, i) => (
+                  <button
+                    key={i}
+                    onClick={() => handleExampleClick(example)}
+                    className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-sm font-medium text-blue-700 hover:bg-blue-100"
+                  >
+                    {example}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <label className="text-md font-medium leading-none mb-1 block text-gray-700">Describe what you're looking for</label>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Describe what you're looking for in plain English..."
+                  value={inputQuery}
+                  onChange={handleInputChange}
+                  onKeyDown={handleKeyDown}
+                  className="h-12 border-gray-300 text-md flex-1"
+                />
+                <Button
+                  onClick={handleTranslate}
+                  disabled={isLoading || !inputQuery.trim()}
+                  className="bg-blue-600 hover:bg-blue-700 text-white h-12"
+                >
+                  {isLoading ? "Translating..." : "Translate"}
+                </Button>
+              </div>
+
+              {errorMessage && (
+                <div className="flex items-center text-red-500 text-sm mt-1">
+                  <AlertCircle className="h-4 w-4 mr-1 flex-shrink-0" />
+                  <span>{errorMessage}</span>
+                </div>
+              )}
+            </div>
+
+            {translatedQuery && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium leading-none m-4 block text-gray-700">
+                  Translated Logsonic Query
+                </label>
+                <CodeExample content={translatedQuery} confidence={confidence} />
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="border-t p-4 bg-gray-50 flex justify-end space-x-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="border-gray-300"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleApplyQuery}
+            disabled={!translatedQuery}
+            className="bg-blue-600 hover:bg-blue-700 text-white"
+          >
+            Apply Query
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/frontend/src/components/Home/AIQueryDialog.tsx
+++ b/frontend/src/components/Home/AIQueryDialog.tsx
@@ -5,7 +5,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { translateQuery } from "@/services/aiService";
-import { useLogResultStore } from "@/stores/useLogResultStore";
 import { useSearchQueryParamsStore } from "@/stores/useSearchQueryParams";
 import { AlertCircle, Check, Copy, Sparkles } from "lucide-react";
 import { useCallback, useState } from "react";
@@ -57,10 +56,9 @@ function CodeExample({ content, confidence }: { content: string; confidence?: nu
 interface AIQueryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onQueryApplied?: (query: string) => void;
 }
 
-export function AIQueryDialog({ open, onOpenChange, onQueryApplied }: AIQueryDialogProps) {
+export function AIQueryDialog({ open, onOpenChange }: AIQueryDialogProps) {
   const [inputQuery, setInputQuery] = useState("");
   const [translatedQuery, setTranslatedQuery] = useState("");
   const [confidence, setConfidence] = useState(0);
@@ -68,7 +66,6 @@ export function AIQueryDialog({ open, onOpenChange, onQueryApplied }: AIQueryDia
   const [errorMessage, setErrorMessage] = useState("");
 
   const store = useSearchQueryParamsStore();
-  const logResultStore = useLogResultStore();
 
   const handleExampleClick = useCallback((example: string) => {
     setInputQuery(example);
@@ -119,21 +116,14 @@ export function AIQueryDialog({ open, onOpenChange, onQueryApplied }: AIQueryDia
 
   const handleApplyQuery = useCallback(() => {
     if (translatedQuery) {
-      // Trim the query to remove any leading/trailing whitespace
-      const trimmedQuery = translatedQuery.trim();
-      
-      // Apply the trimmed query
-      store.setSearchQuery(trimmedQuery);
-      
-      // Call the callback to update the search field in the parent component
-      if (onQueryApplied) {
-        onQueryApplied(trimmedQuery);
-      }
-      
+        store.resetPagination();
+        // Apply the trimmed query
+      store.setSearchQuery(translatedQuery.trim());
+      store.updateUrlParams();
       // Close the dialog
       onOpenChange(false);
     }
-  }, [translatedQuery, store, onOpenChange, onQueryApplied]);
+  }, [translatedQuery, store, onOpenChange]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/Home/AIQueryDialog.tsx
+++ b/frontend/src/components/Home/AIQueryDialog.tsx
@@ -119,7 +119,6 @@ export function AIQueryDialog({ open, onOpenChange }: AIQueryDialogProps) {
         store.resetPagination();
         // Apply the trimmed query
       store.setSearchQuery(translatedQuery.trim());
-      store.updateUrlParams();
       // Close the dialog
       onOpenChange(false);
     }

--- a/frontend/src/components/Home/LogSearch.tsx
+++ b/frontend/src/components/Home/LogSearch.tsx
@@ -31,14 +31,6 @@ export const LogSearch = ({
   const [isAIDialogOpen, setIsAIDialogOpen] = useState(false);
   const [isAIAvailable, setIsAIAvailable] = useState(false);
 
-  // Callback for when AI query is applied
-  const handleQueryApplied = useCallback((query: string) => {
-    setLocalSearchQuery(query);
-    // Trigger a search automatically when an AI query is applied
-    setTimeout(() => {
-      searchLogs();
-    }, 100);
-  }, [searchLogs]);
 
   // Check if AI/Ollama is running
   useEffect(() => {
@@ -62,6 +54,10 @@ export const LogSearch = ({
     return () => clearInterval(intervalId);
   }, []);
 
+  useEffect(() => { 
+    setLocalSearchQuery(store.searchQuery);
+  }, [store.searchQuery]);
+
   // Handle input change without immediately updating the store
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setLocalSearchQuery(e.target.value);
@@ -69,8 +65,9 @@ export const LogSearch = ({
 
   const handleSearch = useCallback((force: boolean = false) => {
     store.resetPagination();
-    store.updateUrlParams();
+
     store.setSearchQuery(localSearchQuery);
+    store.updateUrlParams();
     if (force) {
       searchLogs();
     }
@@ -210,7 +207,7 @@ export const LogSearch = ({
       <AIQueryDialog 
         open={isAIDialogOpen}
         onOpenChange={setIsAIDialogOpen}
-        onQueryApplied={handleQueryApplied}
+
       />
     </div>
   );

--- a/frontend/src/components/Home/LogSearch.tsx
+++ b/frontend/src/components/Home/LogSearch.tsx
@@ -46,12 +46,10 @@ export const LogSearch = ({
       setIsAIAvailable(hasLogsonicModel);
     };
     
+    // Check AI status once on component mount
     checkAI();
     
-    // Check AI status every 30 seconds
-    const intervalId = setInterval(checkAI, 30000);
-    
-    return () => clearInterval(intervalId);
+    // No interval checking - only check when component loads
   }, []);
 
   useEffect(() => { 
@@ -65,9 +63,8 @@ export const LogSearch = ({
 
   const handleSearch = useCallback((force: boolean = false) => {
     store.resetPagination();
-
     store.setSearchQuery(localSearchQuery);
-    store.updateUrlParams();
+
     if (force) {
       searchLogs();
     }
@@ -76,7 +73,7 @@ export const LogSearch = ({
   const handleClearSearch = useCallback(() => {
     setLocalSearchQuery('');
     store.clearSearchQuery();
-    store.updateUrlParams();
+
     store.resetPagination();
   }, [store]);
 
@@ -107,9 +104,9 @@ export const LogSearch = ({
                 >
                   <Sparkles 
                     size={18} 
-                    className="text-yellow-500 hover:text-yellow-600 cursor-pointer"
+                    className="text-blue-500 hover:text-blue-600 cursor-pointer"
                     style={{
-                      filter: 'drop-shadow(0 0 4px rgba(250, 204, 21, 0.5))',
+                      filter: 'drop-shadow(0 0 4px rgba(139, 92, 246, 0.5))',
                       animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite'
                     }}
                   />

--- a/frontend/src/components/Home/LogViewer/LogViewerHeader.tsx
+++ b/frontend/src/components/Home/LogViewer/LogViewerHeader.tsx
@@ -14,7 +14,7 @@ import {
   X,
   XCircle
 } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 
 /**
@@ -34,14 +34,20 @@ export const LogViewerHeader = (
   const { systemInfo } = useSystemInfoStore();
 
   const [isColumnPopoverOpen, setIsColumnPopoverOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [localSearchQuery, setLocalSearchQuery] = useState('');
+
+  // Update search query when it changes asynchronously
+  useEffect(() => {
+    setLocalSearchQuery(store.searchQuery);
+  }, [store.searchQuery]);
+
   
   // Filter out _raw and _src fields
   const availableColumns = store.availableColumns.filter(column => column !== '_raw' && column !== '_src');
 
   // Filter columns based on search query
-  const filteredColumns = searchQuery 
-    ? availableColumns.filter(column => column.toLowerCase().includes(searchQuery.toLowerCase()))
+  const filteredColumns = localSearchQuery 
+    ? availableColumns.filter(column => column.toLowerCase().includes(localSearchQuery.toLowerCase()))
     : availableColumns;
 
   // Handle column selection change
@@ -104,14 +110,14 @@ export const LogViewerHeader = (
                   <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
                   <Input
                     placeholder="Search columns..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    value={localSearchQuery}
+                    onChange={(e) => setLocalSearchQuery(e.target.value)}
                     className="pl-8"
                   />
-                  {searchQuery && (
+                  {localSearchQuery && (
                     <button 
                       className="absolute right-2 top-2.5 text-gray-400 hover:text-gray-600"
-                      onClick={() => setSearchQuery('')}
+                      onClick={() => setLocalSearchQuery('')}
                       aria-label="Clear search"
                     >
                       <XCircle className="h-4 w-4" />

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,25 +1,25 @@
 import {
-  GrokPatternRequest,
-  GrokPatternResponse,
-  IngestFileRequest,
-  IngestRequest,
-  IngestResponse,
-  IngestSessionOptions,
-  LogQueryParams,
-  LogResponse,
-  ParseRequest,
-  ParseResponse,
-  SuggestResponse,
-  SystemInfoResponse,
+    GrokPatternRequest,
+    GrokPatternResponse,
+    IngestFileRequest,
+    IngestRequest,
+    IngestResponse,
+    IngestSessionOptions,
+    LogQueryParams,
+    LogResponse,
+    ParseRequest,
+    ParseResponse,
+    SuggestResponse,
+    SystemInfoResponse,
 } from './api-types';
 
 import {
-  CloudWatchAuth,
-  GetLogEventsRequest,
-  GetLogEventsResponse,
-  ListLogGroupsResponse,
-  ListLogStreamsRequest,
-  ListLogStreamsResponse
+    CloudWatchAuth,
+    GetLogEventsRequest,
+    GetLogEventsResponse,
+    ListLogGroupsResponse,
+    ListLogStreamsRequest,
+    ListLogStreamsResponse
 } from '@/components/Import/CloudWatchImport/types';
 
 // API base configuration
@@ -168,4 +168,41 @@ export async function listCloudWatchLogStreams(request: ListLogStreamsRequest): 
 
 export async function getCloudWatchLogEvents(request: GetLogEventsRequest): Promise<GetLogEventsResponse> {
   return apiRequest<GetLogEventsResponse>('/cloudwatch/log-events', 'POST', request);
+}
+
+// AI API
+export interface AIStatusResponse {
+  ollama_running: boolean;
+  models_available: string[];
+}
+
+export interface AIQueryRequest {
+  columns: string[];
+  query: string;
+}
+
+export interface AIQueryResponse {
+  query: string;
+  confidence: number;
+  available_models: string[];
+  model_used: string;
+  success: boolean;
+  error?: string;
+}
+
+export async function checkAIStatus(): Promise<AIStatusResponse> {
+  try {
+    return await apiRequest<AIStatusResponse>('/ai/status', 'GET');
+  } catch (error) {
+    console.error('Error checking AI status:', error);
+    // Return a default response when the service is unavailable
+    return {
+      ollama_running: false,
+      models_available: [],
+    };
+  }
+}
+
+export async function translateAIQuery(request: AIQueryRequest): Promise<AIQueryResponse> {
+  return apiRequest<AIQueryResponse>('/ai/translate-query', 'POST', request);
 } 

--- a/frontend/src/services/aiService.ts
+++ b/frontend/src/services/aiService.ts
@@ -1,0 +1,10 @@
+import { AIQueryRequest, AIQueryResponse, AIStatusResponse, checkAIStatus as checkStatus, translateAIQuery } from '@/lib/api-client';
+
+// Re-export the types and functions with slightly different names if needed
+export type { AIQueryRequest, AIQueryResponse, AIStatusResponse };
+
+// Check if Ollama and AI services are available
+export const checkAIStatus = checkStatus;
+
+// Translate natural language to Bleve query syntax
+export const translateQuery = translateAIQuery; 

--- a/frontend/src/stores/useSearchQueryParams.ts
+++ b/frontend/src/stores/useSearchQueryParams.ts
@@ -192,6 +192,7 @@ export const useSearchQueryParamsStore = create<SearchQueryParamsStoreState>()(
           const currentState = get();
           if (currentState.searchQuery !== searchQuery) {
             set({ searchQuery });
+            currentState.updateUrlParams();
           }
         },
         setSources: (sources) => {


### PR DESCRIPTION
This PR adds support for querying a custom local modal running via ollama. 

If a local ollama instance is available using predefined model, it will enable menu option converting plain english queries to bleve search syntax.  e.g. 

`"query": "critical errors in database component containing the word 'timeout'"`

is converted into following bleve search syntax. 

`"+severity:critical +component:database +message:timeout"`

This is still an experimental feature and need more testing / fine tuning of the model to cover all cases. 

Nothing should change if ollama is not running or model not found. 