### PR TITLE
Reduce Bleve index size by 53%

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.10
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/blevesearch/bleve/v2 v2.5.7
+	github.com/blevesearch/bleve_index_api v1.2.11
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
 	github.com/google/uuid v1.6.0
@@ -21,7 +22,6 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
 	github.com/axiomhq/drain3 v0.0.0-20260416131915-2b3652f437a5 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
-	github.com/blevesearch/bleve_index_api v1.2.11 // indirect
 	github.com/blevesearch/geo v0.2.4 // indirect
 	github.com/blevesearch/go-faiss v1.0.26 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect

--- a/backend/pkg/storage/index_document.go
+++ b/backend/pkg/storage/index_document.go
@@ -1,0 +1,162 @@
+package storage
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/document"
+	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/blevesearch/bleve/v2/numeric"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+// buildOptimizedDocument applies Bleve's dynamic mapping, preserving the
+// independent field set present in each log row, then removes token metadata
+// that LogSonic never consumes. Phrase queries are verified from stored fields
+// by optimized_query.go, so scoring and term-vector payloads are unnecessary.
+func buildOptimizedDocument(indexMapping mapping.IndexMapping, id string, data interface{}) (*document.Document, error) {
+	doc := document.NewDocument(id)
+	if err := indexMapping.MapDocument(doc, data); err != nil {
+		return nil, err
+	}
+	// Existing shards may still carry the legacy mapping that creates _all.
+	// Never append that duplicate composite to newly indexed documents.
+	doc.CompositeFields = nil
+
+	for i, field := range doc.Fields {
+		if !field.Options().IsIndexed() {
+			continue
+		}
+
+		options := field.Options() | index.SkipFreqNorm
+		switch typed := field.(type) {
+		case *document.TextField:
+			options &^= index.IncludeTermVectors
+			doc.Fields[i] = document.NewTextFieldCustom(
+				typed.Name(),
+				typed.ArrayPositions(),
+				typed.Value(),
+				options,
+				typed.Analyzer(),
+			)
+		case *document.NumericField:
+			number, err := typed.Number()
+			if err != nil {
+				return nil, fmt.Errorf("decode numeric field %q: %w", typed.Name(), err)
+			}
+			doc.Fields[i] = newCompactNumericField(
+				typed.Name(), typed.ArrayPositions(), number, options,
+			)
+		case *document.BooleanField:
+			value, err := typed.Boolean()
+			if err != nil {
+				return nil, fmt.Errorf("decode boolean field %q: %w", typed.Name(), err)
+			}
+			doc.Fields[i] = document.NewBooleanFieldWithIndexingOptions(
+				typed.Name(), typed.ArrayPositions(), value, options,
+			)
+		case *document.DateTimeField:
+			value, layout, err := typed.DateTime()
+			if err != nil {
+				return nil, fmt.Errorf("decode datetime field %q: %w", typed.Name(), err)
+			}
+			optimized, err := document.NewDateTimeFieldWithIndexingOptions(
+				typed.Name(), typed.ArrayPositions(), value, layout, options,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("optimize datetime field %q: %w", typed.Name(), err)
+			}
+			doc.Fields[i] = optimized
+		}
+	}
+
+	return doc, nil
+}
+
+// compactNumericField stores the same sortable shift-0 term used by Bleve,
+// without the additional 15 legacy trie terms. Numeric range queries are
+// rewritten to scan this ordered term dictionary in optimized_query.go.
+type compactNumericField struct {
+	name           string
+	arrayPositions []uint64
+	options        index.FieldIndexingOptions
+	value          numeric.PrefixCoded
+	length         int
+	frequencies    index.TokenFrequencies
+}
+
+func newCompactNumericField(
+	name string,
+	arrayPositions []uint64,
+	number float64,
+	options index.FieldIndexingOptions,
+) *compactNumericField {
+	value := numeric.MustNewPrefixCodedInt64(numeric.Float64ToInt64(number), 0)
+	return &compactNumericField{
+		name:           name,
+		arrayPositions: arrayPositions,
+		options:        options,
+		value:          value,
+	}
+}
+
+func (f *compactNumericField) Name() string {
+	return f.name
+}
+
+func (f *compactNumericField) ArrayPositions() []uint64 {
+	return f.arrayPositions
+}
+
+func (f *compactNumericField) Options() index.FieldIndexingOptions {
+	return f.options
+}
+
+func (f *compactNumericField) Analyze() {
+	tokens := analysis.TokenStream{{
+		Term:     f.value,
+		Position: 1,
+		Type:     analysis.Numeric,
+	}}
+	f.length = 1
+	f.frequencies = analysis.TokenFrequency(tokens, f.arrayPositions, f.options)
+}
+
+func (f *compactNumericField) Value() []byte {
+	return f.value
+}
+
+func (f *compactNumericField) Number() (float64, error) {
+	value, err := f.value.Int64()
+	if err != nil {
+		return 0, err
+	}
+	return numeric.Int64ToFloat64(value), nil
+}
+
+func (f *compactNumericField) NumPlainTextBytes() uint64 {
+	return uint64(len(f.value))
+}
+
+func (f *compactNumericField) Size() int {
+	size := int(reflect.TypeOf(*f).Size()) + len(f.name) + len(f.value)
+	if f.frequencies != nil {
+		size += f.frequencies.Size()
+	}
+	return size
+}
+
+func (f *compactNumericField) EncodedFieldType() byte {
+	return 'n'
+}
+
+func (f *compactNumericField) AnalyzedLength() int {
+	return f.length
+}
+
+func (f *compactNumericField) AnalyzedTokenFrequencies() index.TokenFrequencies {
+	return f.frequencies
+}
+
+var _ index.NumericField = (*compactNumericField)(nil)

--- a/backend/pkg/storage/index_size_benchmark_test.go
+++ b/backend/pkg/storage/index_size_benchmark_test.go
@@ -1,0 +1,118 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const defaultSizeBenchmarkMiB = 32
+
+// BenchmarkIndexSizeDense measures storage amplification for a large log file
+// whose events fall on one day. Run with -benchtime=1x; LOGSONIC_SIZE_BENCH_MB
+// can override the default 32 MiB raw payload.
+func BenchmarkIndexSizeDense(b *testing.B) {
+	benchmarkIndexSize(b, 1)
+}
+
+// BenchmarkIndexSizeSpread measures the fixed cost of date sharding by
+// spreading the same raw payload over a year.
+func BenchmarkIndexSizeSpread(b *testing.B) {
+	benchmarkIndexSize(b, 365)
+}
+
+func benchmarkIndexSize(b *testing.B, days int) {
+	targetBytes := int64(defaultSizeBenchmarkMiB * 1024 * 1024)
+	if raw := os.Getenv("LOGSONIC_SIZE_BENCH_MB"); raw != "" {
+		mib, err := strconv.Atoi(raw)
+		if err != nil || mib <= 0 {
+			b.Fatalf("invalid LOGSONIC_SIZE_BENCH_MB %q", raw)
+		}
+		targetBytes = int64(mib) * 1024 * 1024
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		dir := filepath.Join(b.TempDir(), "index")
+		store, err := NewStorage(dir)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		const batchSize = 10_000
+		base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		var rawBytes int64
+		var seq int64
+		for rawBytes < targetBytes {
+			logs := make([]map[string]interface{}, 0, batchSize)
+			for len(logs) < batchSize && rawBytes < targetBytes {
+				seq++
+				raw := fmt.Sprintf(
+					`10.%d.%d.%d - user-%d [01/Jan/2025:00:00:00 +0000] "GET /api/v1/orders/%d?region=eu HTTP/1.1" %d %d "https://app.example.com/orders" "logsonic-size-benchmark/1.0" request_id=req-%012d upstream=orders-api message="upstream connection timeout after 1500ms"`,
+					seq%250,
+					(seq/250)%250,
+					(seq/62_500)%250,
+					seq%10_000,
+					seq,
+					200+(seq%5)*100,
+					512+seq%65_536,
+					seq,
+				)
+				rawBytes += int64(len(raw) + 1)
+				ts := base.AddDate(0, 0, int(seq%int64(days))).Add(time.Duration(seq%86_400) * time.Second)
+				logs = append(logs, map[string]interface{}{
+					"timestamp":  ts,
+					"_raw":       raw,
+					"_src":       "file.access.log",
+					"_seq":       seq,
+					"client_ip":  fmt.Sprintf("10.%d.%d.%d", seq%250, (seq/250)%250, (seq/62_500)%250),
+					"user":       fmt.Sprintf("user-%d", seq%10_000),
+					"method":     "GET",
+					"url":        fmt.Sprintf("/api/v1/orders/%d?region=eu", seq),
+					"status":     strconv.FormatInt(200+(seq%5)*100, 10),
+					"bytes":      strconv.FormatInt(512+seq%65_536, 10),
+					"referrer":   "https://app.example.com/orders",
+					"user_agent": "logsonic-size-benchmark/1.0",
+					"request_id": fmt.Sprintf("req-%012d", seq),
+					"upstream":   "orders-api",
+					"message":    "upstream connection timeout after 1500ms",
+					"level":      "error",
+				})
+			}
+			if err := store.Store(logs, "access.log"); err != nil {
+				store.Close()
+				b.Fatal(err)
+			}
+		}
+
+		if err := store.Close(); err != nil {
+			b.Fatal(err)
+		}
+		indexBytes, err := directorySize(dir)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportMetric(float64(rawBytes)/(1024*1024), "raw-MiB")
+		b.ReportMetric(float64(indexBytes)/(1024*1024), "index-MiB")
+		b.ReportMetric(float64(indexBytes)/float64(rawBytes), "index/raw")
+		b.ReportMetric(float64(seq), "docs")
+	}
+}
+
+func directorySize(root string) (int64, error) {
+	var total int64
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
+}

--- a/backend/pkg/storage/optimized_query.go
+++ b/backend/pkg/storage/optimized_query.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/blevesearch/bleve/v2/analysis"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -27,11 +28,20 @@ func optimizeQuery(input query.Query) query.Query {
 			fuzziness: typed.Fuzziness,
 		}
 	case *query.NumericRangeQuery:
+		// An open bound must still be clamped to the numeric term space.
+		// Every shift-0 numeric term begins with byte 0x20, while standard
+		// analyzer text terms begin at 0x30+, so an unbounded ("") upper
+		// bound would sweep past the numeric terms into any non-numeric text
+		// values stored in the same dynamic field. Clamp open bounds to the
+		// min/max int64 terms instead, which keeps the scan inside the
+		// numeric dictionary.
+		minBound, inclusiveMin := compactNumericLowerBound(typed.Min, typed.InclusiveMin)
+		maxBound, inclusiveMax := compactNumericUpperBound(typed.Max, typed.InclusiveMax)
 		numericRange := query.NewTermRangeInclusiveQuery(
-			compactNumericBound(typed.Min),
-			compactNumericBound(typed.Max),
-			typed.InclusiveMin,
-			typed.InclusiveMax,
+			minBound,
+			maxBound,
+			inclusiveMin,
+			inclusiveMax,
 		)
 		numericRange.SetField(typed.FieldVal)
 		numericRange.SetBoost(typed.Boost())
@@ -62,6 +72,27 @@ func optimizeOptionalQuery(input query.Query) query.Query {
 		return nil
 	}
 	return optimizeQuery(input)
+}
+
+// compactNumericLowerBound returns the shift-0 term for an inclusive/exclusive
+// numeric lower bound. A nil bound clamps to the minimum int64 term so the
+// range stays within the numeric dictionary rather than starting before it.
+func compactNumericLowerBound(value *float64, inclusive *bool) (string, *bool) {
+	if value == nil {
+		clamp := true
+		return string(numeric.MustNewPrefixCodedInt64(math.MinInt64, 0)), &clamp
+	}
+	return compactNumericBound(value), inclusive
+}
+
+// compactNumericUpperBound mirrors compactNumericLowerBound for upper bounds,
+// clamping a nil bound to the maximum int64 term.
+func compactNumericUpperBound(value *float64, inclusive *bool) (string, *bool) {
+	if value == nil {
+		clamp := true
+		return string(numeric.MustNewPrefixCodedInt64(math.MaxInt64, 0)), &clamp
+	}
+	return compactNumericBound(value), inclusive
 }
 
 func compactNumericBound(value *float64) string {

--- a/backend/pkg/storage/optimized_query.go
+++ b/backend/pkg/storage/optimized_query.go
@@ -1,0 +1,333 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/blevesearch/bleve/v2/numeric"
+	"github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/search/query"
+	"github.com/blevesearch/bleve/v2/search/searcher"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+// optimizeQuery rewrites operations whose default Bleve representation needs
+// the redundant index data omitted by buildOptimizedDocument.
+func optimizeQuery(input query.Query) query.Query {
+	optimized := input
+	switch typed := input.(type) {
+	case *query.MatchPhraseQuery:
+		optimized = &storedPhraseQuery{
+			phrase:    typed.MatchPhrase,
+			field:     typed.FieldVal,
+			analyzer:  typed.Analyzer,
+			boost:     typed.Boost(),
+			fuzziness: typed.Fuzziness,
+		}
+	case *query.NumericRangeQuery:
+		numericRange := query.NewTermRangeInclusiveQuery(
+			compactNumericBound(typed.Min),
+			compactNumericBound(typed.Max),
+			typed.InclusiveMin,
+			typed.InclusiveMax,
+		)
+		numericRange.SetField(typed.FieldVal)
+		numericRange.SetBoost(typed.Boost())
+		optimized = numericRange
+	case *query.ConjunctionQuery:
+		for i, child := range typed.Conjuncts {
+			typed.Conjuncts[i] = optimizeQuery(child)
+		}
+	case *query.DisjunctionQuery:
+		for i, child := range typed.Disjuncts {
+			typed.Disjuncts[i] = optimizeQuery(child)
+		}
+	case *query.BooleanQuery:
+		typed.Must = optimizeOptionalQuery(typed.Must)
+		typed.Should = optimizeOptionalQuery(typed.Should)
+		typed.MustNot = optimizeOptionalQuery(typed.MustNot)
+		typed.Filter = optimizeOptionalQuery(typed.Filter)
+	}
+
+	if fieldable, ok := optimized.(query.FieldableQuery); ok && fieldable.Field() == "" {
+		return &allFieldsQuery{child: fieldable}
+	}
+	return optimized
+}
+
+func optimizeOptionalQuery(input query.Query) query.Query {
+	if input == nil {
+		return nil
+	}
+	return optimizeQuery(input)
+}
+
+func compactNumericBound(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return string(numeric.MustNewPrefixCodedInt64(numeric.Float64ToInt64(*value), 0))
+}
+
+// storedPhraseQuery verifies phrase positions against stored field values
+// instead of Bleve term vectors. Candidate selection still uses the inverted
+// index, so only documents containing every phrase term are read.
+type storedPhraseQuery struct {
+	phrase    string
+	field     string
+	analyzer  string
+	boost     float64
+	fuzziness int
+}
+
+func (q *storedPhraseQuery) Searcher(
+	ctx context.Context,
+	reader index.IndexReader,
+	indexMapping mapping.IndexMapping,
+	options search.SearcherOptions,
+) (search.Searcher, error) {
+	field := q.field
+	if field == "" {
+		fields, err := searchableFields(reader)
+		if err != nil {
+			return nil, err
+		}
+		queries := make([]query.Query, 0, len(fields))
+		for _, field := range fields {
+			fieldQuery := *q
+			fieldQuery.field = field
+			queries = append(queries, &fieldQuery)
+		}
+		if len(queries) == 0 {
+			return query.NewMatchNoneQuery().Searcher(ctx, reader, indexMapping, options)
+		}
+		return query.NewDisjunctionQuery(queries).Searcher(ctx, reader, indexMapping, options)
+	}
+
+	analyzerName := q.analyzer
+	if analyzerName == "" {
+		analyzerName = indexMapping.AnalyzerNameForPath(field)
+	}
+	analyzer := indexMapping.AnalyzerNamed(analyzerName)
+	if analyzer == nil {
+		return nil, fmt.Errorf("no analyzer named %q registered", analyzerName)
+	}
+
+	phrase := analyzePhrase(analyzer.Analyze([]byte(q.phrase)))
+	if len(phrase) == 0 {
+		return query.NewMatchNoneQuery().Searcher(ctx, reader, indexMapping, options)
+	}
+
+	candidates := make([]query.Query, 0, len(phrase))
+	for _, positionTerms := range phrase {
+		alternatives := make([]query.Query, 0, len(positionTerms))
+		for _, term := range positionTerms {
+			if q.fuzziness > 0 {
+				candidate := query.NewFuzzyQuery(term)
+				candidate.SetFuzziness(q.fuzziness)
+				candidate.SetField(field)
+				candidate.SetBoost(q.boost)
+				alternatives = append(alternatives, candidate)
+			} else {
+				candidate := query.NewTermQuery(term)
+				candidate.SetField(field)
+				candidate.SetBoost(q.boost)
+				alternatives = append(alternatives, candidate)
+			}
+		}
+		if len(alternatives) == 1 {
+			candidates = append(candidates, alternatives[0])
+		} else {
+			candidates = append(candidates, query.NewDisjunctionQuery(alternatives))
+		}
+	}
+
+	candidateSearcher, err := query.NewConjunctionQuery(candidates).Searcher(ctx, reader, indexMapping, options)
+	if err != nil {
+		return nil, err
+	}
+	if len(phrase) == 1 {
+		return candidateSearcher, nil
+	}
+
+	return searcher.NewFilteringSearcher(ctx, candidateSearcher, func(_ *search.SearchContext, match *search.DocumentMatch) bool {
+		id, err := reader.ExternalID(match.IndexInternalID)
+		if err != nil {
+			return false
+		}
+		doc, err := reader.Document(id)
+		if err != nil || doc == nil {
+			return false
+		}
+
+		matched := false
+		doc.VisitFields(func(stored index.Field) {
+			if matched || stored.EncodedFieldType() != 't' ||
+				stored.Name() != field && field != "_all" {
+				return
+			}
+			tokens := analyzer.Analyze(append([]byte(nil), stored.Value()...))
+			matched = phraseMatches(phrase, tokens, q.fuzziness)
+		})
+		return matched
+	}), nil
+}
+
+// allFieldsQuery replaces Bleve's on-disk _all composite. It executes an
+// unqualified field-aware query against each searchable field and combines the
+// results, preserving the old cross-field behavior without duplicating terms.
+type allFieldsQuery struct {
+	child query.FieldableQuery
+}
+
+func (q *allFieldsQuery) Searcher(
+	ctx context.Context,
+	reader index.IndexReader,
+	indexMapping mapping.IndexMapping,
+	options search.SearcherOptions,
+) (search.Searcher, error) {
+	fields, err := searchableFields(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	searchers := make([]search.Searcher, 0, len(fields))
+	originalField := q.child.Field()
+	defer q.child.SetField(originalField)
+	for _, field := range fields {
+		q.child.SetField(field)
+		fieldSearcher, err := q.child.Searcher(ctx, reader, indexMapping, options)
+		if err != nil {
+			for _, opened := range searchers {
+				_ = opened.Close()
+			}
+			return nil, err
+		}
+		searchers = append(searchers, fieldSearcher)
+	}
+	if len(searchers) == 0 {
+		return query.NewMatchNoneQuery().Searcher(ctx, reader, indexMapping, options)
+	}
+	return searcher.NewDisjunctionSearcher(ctx, reader, searchers, 0, options)
+}
+
+func searchableFields(reader index.IndexReader) ([]string, error) {
+	fields, err := reader.Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	searchable := make([]string, 0, len(fields))
+	for _, field := range fields {
+		switch field {
+		case "_all", "_id", "_seq", "timestamp":
+			continue
+		default:
+			searchable = append(searchable, field)
+		}
+	}
+	return searchable, nil
+}
+
+func analyzePhrase(tokens analysis.TokenStream) [][]string {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	firstPosition := tokens[0].Position
+	lastPosition := tokens[0].Position
+	for _, token := range tokens[1:] {
+		if token.Position < firstPosition {
+			firstPosition = token.Position
+		}
+		if token.Position > lastPosition {
+			lastPosition = token.Position
+		}
+	}
+
+	phrase := make([][]string, lastPosition-firstPosition+1)
+	for _, token := range tokens {
+		position := token.Position - firstPosition
+		phrase[position] = append(phrase[position], string(token.Term))
+	}
+	return phrase
+}
+
+func phraseMatches(phrase [][]string, tokens analysis.TokenStream, fuzziness int) bool {
+	if len(phrase) == 0 || len(tokens) == 0 {
+		return false
+	}
+
+	termsByPosition := make(map[int][]string)
+	for _, token := range tokens {
+		termsByPosition[token.Position] = append(termsByPosition[token.Position], string(token.Term))
+	}
+
+	for start := range termsByPosition {
+		matched := true
+		for offset, wanted := range phrase {
+			if len(wanted) == 0 {
+				continue
+			}
+			if !matchesAnyTerm(wanted, termsByPosition[start+offset], fuzziness) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAnyTerm(wanted, actual []string, fuzziness int) bool {
+	for _, expected := range wanted {
+		for _, candidate := range actual {
+			if expected == candidate || fuzziness > 0 && editDistanceAtMost(expected, candidate, fuzziness) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func editDistanceAtMost(a, b string, limit int) bool {
+	if limit < 0 || abs(len(a)-len(b)) > limit {
+		return false
+	}
+	previous := make([]int, len(b)+1)
+	current := make([]int, len(b)+1)
+	for j := range previous {
+		previous[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		current[0] = i
+		rowMin := current[0]
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			current[j] = min(previous[j]+1, current[j-1]+1, previous[j-1]+cost)
+			rowMin = min(rowMin, current[j])
+		}
+		if rowMin > limit {
+			return false
+		}
+		previous, current = current, previous
+	}
+	return previous[len(b)] <= limit
+}
+
+func abs(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+var _ query.Query = (*storedPhraseQuery)(nil)
+var _ query.Query = (*allFieldsQuery)(nil)

--- a/backend/pkg/storage/search.go
+++ b/backend/pkg/storage/search.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -123,10 +122,15 @@ func (s *Storage) Search(queryStr string, startDate, endDate *time.Time, sources
 				if queryStr != "" {
 					unescapedQueryStr, err := url.PathUnescape(queryStr)
 					if err != nil {
+						resultChan <- indexResult{err: fmt.Errorf("invalid query encoding: %w", err)}
 						return
 					}
-					// Use Bleve's built-in query string parser
-					searchQuery = bleve.NewQueryStringQuery(unescapedQueryStr)
+					parsedQuery, err := bleve.NewQueryStringQuery(unescapedQueryStr).Parse()
+					if err != nil {
+						resultChan <- indexResult{err: fmt.Errorf("invalid query: %w", err)}
+						return
+					}
+					searchQuery = optimizeQuery(parsedQuery)
 
 				} else {
 					searchQuery = bleve.NewMatchAllQuery()
@@ -134,7 +138,15 @@ func (s *Storage) Search(queryStr string, startDate, endDate *time.Time, sources
 
 				// Add source filter if provided
 				if len(sources) > 0 {
-					sourceFilter := bleve.NewQueryStringQuery(strings.Join(sources, ","))
+					sourceQueries := make([]query.Query, 0, len(sources))
+					for _, source := range sources {
+						sourceQueries = append(sourceQueries, &storedPhraseQuery{
+							phrase: source,
+							field:  "_src",
+							boost:  1,
+						})
+					}
+					sourceFilter := bleve.NewDisjunctionQuery(sourceQueries...)
 					searchQuery = bleve.NewConjunctionQuery(searchQuery, sourceFilter)
 				}
 

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -111,6 +111,10 @@ func buildIndexMapping() mapping.IndexMapping {
 	textField.Analyzer = "standard"
 	textField.IncludeTermVectors = false
 	textField.IncludeInAll = false
+	// Doc values build a columnar copy of every term, used only for sorting
+	// and faceting at the Bleve layer. LogSonic sorts results in Go and never
+	// facets, so the _raw doc-values payload is dead weight — disable it.
+	textField.DocValues = false
 	logMapping.AddFieldMappingsAt("_raw", textField)
 
 	// _seq is internal ordering metadata (the sort tie-breaker). Persist it

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -97,38 +97,41 @@ func (s *Storage) Close() error {
 
 // buildIndexMapping returns the standard Bleve index mapping used for all shards.
 func buildIndexMapping() mapping.IndexMapping {
-	mapping := bleve.NewIndexMapping()
+	indexMapping := bleve.NewIndexMapping()
 	logMapping := bleve.NewDocumentMapping()
 
 	dateField := bleve.NewDateTimeFieldMapping()
 	dateField.Store = true
 	dateField.Index = false
+	dateField.IncludeInAll = false
 	logMapping.AddFieldMappingsAt("timestamp", dateField)
 
 	textField := bleve.NewTextFieldMapping()
 	textField.Store = true
 	textField.Analyzer = "standard"
 	textField.IncludeTermVectors = false
-	textField.IncludeInAll = true
+	textField.IncludeInAll = false
 	logMapping.AddFieldMappingsAt("_raw", textField)
 
-	// _seq is internal ordering metadata (the sort tie-breaker). Persist
-	// it so it round-trips for sorting, but keep it out of the index and
-	// the _all field — otherwise IndexDynamic would make its numeric
-	// value searchable and a free-text query containing a number could
-	// match documents on their _seq.
+	// _seq is internal ordering metadata (the sort tie-breaker). Persist it
+	// so it round-trips for sorting, but keep it out of the field index.
 	seqField := bleve.NewNumericFieldMapping()
 	seqField.Store = true
 	seqField.Index = false
 	seqField.IncludeInAll = false
 	logMapping.AddFieldMappingsAt("_seq", seqField)
 
-	mapping.DefaultMapping = logMapping
-	mapping.DefaultAnalyzer = "standard"
-	mapping.IndexDynamic = true
-	mapping.StoreDynamic = true
-	mapping.DocValuesDynamic = false
-	return mapping
+	// The default _all composite re-indexed _raw plus every parsed field,
+	// causing several copies of the same content on disk. Search replaces it
+	// with an all-fields query at runtime, so disable the stored composite.
+	logMapping.AddSubDocumentMapping("_all", bleve.NewDocumentDisabledMapping())
+	indexMapping.DefaultField = "_raw"
+	indexMapping.DefaultMapping = logMapping
+	indexMapping.DefaultAnalyzer = "standard"
+	indexMapping.IndexDynamic = true
+	indexMapping.StoreDynamic = true
+	indexMapping.DocValuesDynamic = false
+	return indexMapping
 }
 
 // kvConfig is the LevelDB configuration shared by all Bleve shards.
@@ -230,8 +233,12 @@ func (s *Storage) Store(logs []map[string]interface{}, source string) error {
 				seqID = v
 			}
 			docID := fmt.Sprintf("%d-%s-%d", log["timestamp"].(time.Time).UnixNano(), source, seqID)
-			if err := batch.Index(docID, logCopy); err != nil {
+			doc, err := buildOptimizedDocument(index.Mapping(), docID, logCopy)
+			if err != nil {
 				return fmt.Errorf("failed to index log entry: %w", err)
+			}
+			if err := batch.IndexAdvanced(doc); err != nil {
+				return fmt.Errorf("failed to add log entry to batch: %w", err)
 			}
 		}
 		if err := index.Batch(batch); err != nil {
@@ -365,34 +372,34 @@ func (s *Storage) GetDocCount(date string) (uint64, error) {
 func (s *Storage) DeleteByIds(ids []string) (int, error) {
 	// Track how many logs were deleted
 	deletedCount := 0
-	
+
 	// Convert ids array to a map for faster lookups
 	idMap := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		idMap[id] = true
 	}
-	
+
 	// Get all available dates
 	dates, err := s.List()
 	if err != nil {
 		return 0, fmt.Errorf("failed to list available dates: %w", err)
 	}
-	
+
 	// For each date index, check for matching document IDs
 	for _, date := range dates {
 		index, err := s.getOrCreateIndex(date)
 		if err != nil {
 			return deletedCount, fmt.Errorf("failed to get index for date %s: %w", date, err)
 		}
-		
+
 		// Create a batch for deletions
 		batch := index.NewBatch()
-		
+
 		// Process each ID
 		for id := range idMap {
 			batch.Delete(id)
 		}
-		
+
 		// Only execute the batch if there are operations to perform
 		if batch.Size() > 0 {
 			if err := index.Batch(batch); err != nil {
@@ -403,6 +410,6 @@ func (s *Storage) DeleteByIds(ids []string) (int, error) {
 			deletedCount += batch.Size()
 		}
 	}
-	
+
 	return deletedCount, nil
 }

--- a/backend/pkg/storage/storage_test.go
+++ b/backend/pkg/storage/storage_test.go
@@ -542,6 +542,60 @@ func TestStore_MultipleSourcesSameDate(t *testing.T) {
 	}
 }
 
+// TestSearch_OpenNumericRangeExcludesTextTerms guards the numeric-range
+// rewrite against leaking non-numeric values from a mixed-type field. An
+// open-upper range (>, >=) must not match text terms, which sort above the
+// shift-0 numeric terms in the same field's dictionary.
+func TestSearch_OpenNumericRangeExcludesTextTerms(t *testing.T) {
+	store, _ := setupTestStorage(t)
+
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	logs := []map[string]interface{}{
+		{"timestamp": ts, "_raw": "fast", "_src": "x.log", "latency": "100"},
+		{"timestamp": ts.Add(time.Minute), "_raw": "slow", "_src": "x.log", "latency": "timeout"},
+		{"timestamp": ts.Add(2 * time.Minute), "_raw": "quick", "_src": "x.log", "latency": "20"},
+	}
+	if err := store.Store(logs, "x.log"); err != nil {
+		t.Fatalf("Store failed: %v", err)
+	}
+
+	start := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 15, 23, 59, 59, 0, time.UTC)
+
+	cases := []struct {
+		query string
+		want  []string
+	}{
+		{"latency:>50", []string{"100"}},
+		{"latency:>=100", []string{"100"}},
+		{"latency:>0", []string{"20", "100"}},
+		{"latency:<200", []string{"20", "100"}},
+		{"latency:>600", nil},
+	}
+	for _, tc := range cases {
+		results, _, err := store.Search(tc.query, &start, &end, nil)
+		if err != nil {
+			t.Fatalf("Search(%q) failed: %v", tc.query, err)
+		}
+		got := make(map[string]bool, len(results))
+		for _, result := range results {
+			got[fmt.Sprintf("%v", result["latency"])] = true
+			if result["latency"] == "timeout" {
+				t.Errorf("Search(%q) leaked non-numeric latency value: %#v", tc.query, result)
+			}
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("Search(%q) returned %v, want %v", tc.query, results, tc.want)
+			continue
+		}
+		for _, want := range tc.want {
+			if !got[want] {
+				t.Errorf("Search(%q) missing latency %q; got %v", tc.query, want, results)
+			}
+		}
+	}
+}
+
 func TestSearch_MultipleSourcesKeepIndependentFields(t *testing.T) {
 	store, _ := setupTestStorage(t)
 

--- a/backend/pkg/storage/storage_test.go
+++ b/backend/pkg/storage/storage_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/blevesearch/bleve/v2"
 )
 
 // ---------------------------------------------------------------------------
@@ -537,6 +539,217 @@ func TestStore_MultipleSourcesSameDate(t *testing.T) {
 	}
 	if len(sources) != 3 {
 		t.Errorf("expected 3 source names, got %d: %v", len(sources), sources)
+	}
+}
+
+func TestSearch_MultipleSourcesKeepIndependentFields(t *testing.T) {
+	store, _ := setupTestStorage(t)
+
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	nginxLogs := []map[string]interface{}{
+		{
+			"timestamp": ts,
+			"_raw":      `GET /checkout returned 503 from upstream`,
+			"_src":      "nginx.access.log",
+			"method":    "GET",
+			"url":       "/checkout",
+			"status":    "503",
+		},
+		{
+			"timestamp": ts.Add(time.Minute),
+			"_raw":      `GET /health returned 200`,
+			"_src":      "nginx.access.log",
+			"method":    "GET",
+			"url":       "/health",
+			"status":    "200",
+		},
+	}
+	appLogs := []map[string]interface{}{
+		{
+			"timestamp":  ts.Add(2 * time.Minute),
+			"_raw":       `billing worker connection timeout after retry`,
+			"_src":       "app.service.log",
+			"level":      "error",
+			"service":    "billing-worker",
+			"message":    "connection timeout after retry",
+			"deployment": "blue canary",
+		},
+		{
+			"timestamp": ts.Add(3 * time.Minute),
+			"_raw":      `billing worker completed request`,
+			"_src":      "app.service.log",
+			"level":     "info",
+			"service":   "billing-worker",
+			"message":   "completed request",
+		},
+	}
+
+	if err := store.Store(nginxLogs, "nginx.access.log"); err != nil {
+		t.Fatalf("Store nginx logs failed: %v", err)
+	}
+	if err := store.Store(appLogs, "app.service.log"); err != nil {
+		t.Fatalf("Store app logs failed: %v", err)
+	}
+
+	start := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 15, 23, 59, 59, 0, time.UTC)
+
+	assertSearch := func(query string, sources []string, want int, verify func(map[string]interface{})) {
+		t.Helper()
+		results, _, err := store.Search(query, &start, &end, sources)
+		if err != nil {
+			t.Fatalf("Search(%q, %v) failed: %v", query, sources, err)
+		}
+		if len(results) != want {
+			t.Fatalf("Search(%q, %v) returned %d results, want %d: %#v", query, sources, len(results), want, results)
+		}
+		for _, result := range results {
+			verify(result)
+		}
+	}
+
+	assertSearch("status:>=500", nil, 1, func(result map[string]interface{}) {
+		if result["_src"] != "nginx.access.log" || result["url"] != "/checkout" {
+			t.Errorf("numeric range returned wrong nginx row: %#v", result)
+		}
+		if _, exists := result["service"]; exists {
+			t.Errorf("nginx row unexpectedly contains app-only service field: %#v", result)
+		}
+	})
+	assertSearch("status:503", nil, 1, func(result map[string]interface{}) {
+		if result["_src"] != "nginx.access.log" {
+			t.Errorf("numeric equality returned wrong source: %#v", result)
+		}
+	})
+	assertSearch("503", nil, 1, func(result map[string]interface{}) {
+		if result["_src"] != "nginx.access.log" {
+			t.Errorf("bare numeric query returned wrong source: %#v", result)
+		}
+	})
+	assertSearch("status:>200", nil, 1, func(result map[string]interface{}) {
+		if result["url"] != "/checkout" {
+			t.Errorf("exclusive numeric range returned wrong row: %#v", result)
+		}
+	})
+	assertSearch(`message:"connection timeout"`, nil, 1, func(result map[string]interface{}) {
+		if result["_src"] != "app.service.log" || result["service"] != "billing-worker" {
+			t.Errorf("field phrase returned wrong app row: %#v", result)
+		}
+		if _, exists := result["status"]; exists {
+			t.Errorf("app row unexpectedly contains nginx-only status field: %#v", result)
+		}
+	})
+	assertSearch(`"connection timeout"`, nil, 1, func(result map[string]interface{}) {
+		if result["_src"] != "app.service.log" {
+			t.Errorf("bare phrase returned wrong source: %#v", result)
+		}
+	})
+	assertSearch("canary", nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("bare parsed-field term returned wrong row: %#v", result)
+		}
+	})
+	assertSearch(`"blue canary"`, nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("bare parsed-field phrase returned wrong row: %#v", result)
+		}
+	})
+	assertSearch("canar*", nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("bare wildcard returned wrong row: %#v", result)
+		}
+	})
+	assertSearch("/canar.*/", nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("bare regexp returned wrong row: %#v", result)
+		}
+	})
+	assertSearch("canarz~1", nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("bare fuzzy query returned wrong row: %#v", result)
+		}
+	})
+	assertSearch("+level:error +deployment:canary", nil, 1, func(result map[string]interface{}) {
+		if result["deployment"] != "blue canary" {
+			t.Errorf("boolean query returned wrong row: %#v", result)
+		}
+	})
+	assertSearch(`message:"timeout connection"`, nil, 0, func(map[string]interface{}) {})
+	assertSearch("", []string{"nginx.access.log"}, 2, func(result map[string]interface{}) {
+		if result["_src"] != "nginx.access.log" {
+			t.Errorf("source filter returned wrong row: %#v", result)
+		}
+	})
+	assertSearch("level:error", []string{"app.service.log"}, 1, func(result map[string]interface{}) {
+		if result["_src"] != "app.service.log" {
+			t.Errorf("field query and source filter returned wrong row: %#v", result)
+		}
+	})
+
+	sources, err := store.GetSourceNames()
+	if err != nil {
+		t.Fatalf("GetSourceNames failed: %v", err)
+	}
+	sourceSet := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		sourceSet[source] = true
+	}
+	if !sourceSet["nginx.access.log"] || !sourceSet["app.service.log"] || len(sourceSet) != 2 {
+		t.Fatalf("GetSourceNames returned wrong sources: %v", sources)
+	}
+}
+
+func TestSearch_OptimizedQueriesReadLegacyIndex(t *testing.T) {
+	dir := t.TempDir()
+	date := "2024-01-15"
+	indexPath := filepath.Join(dir, "logs-"+date+".bleve")
+	legacyIndex, err := bleve.New(indexPath, bleve.NewIndexMapping())
+	if err != nil {
+		t.Fatalf("create legacy index: %v", err)
+	}
+
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	if err := legacyIndex.Index("legacy-1", map[string]interface{}{
+		"timestamp": ts,
+		"_raw":      "legacy connection timeout",
+		"_src":      "legacy.log",
+		"message":   "connection timeout",
+		"status":    503,
+	}); err != nil {
+		legacyIndex.Close()
+		t.Fatalf("index legacy document: %v", err)
+	}
+
+	store := &Storage{
+		baseDir: dir,
+		indices: map[string]bleve.Index{date: legacyIndex},
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.Store([]map[string]interface{}{{
+		"timestamp": ts.Add(time.Minute),
+		"_raw":      "new connection timeout",
+		"_src":      "legacy.log",
+		"message":   "connection timeout",
+		"status":    "504",
+	}}, "legacy.log"); err != nil {
+		t.Fatalf("append optimized document to legacy index: %v", err)
+	}
+
+	start := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 15, 23, 59, 59, 0, time.UTC)
+	for _, query := range []string{`"connection timeout"`, `message:"connection timeout"`, "status:>=500"} {
+		results, _, err := store.Search(query, &start, &end, nil)
+		if err != nil {
+			t.Fatalf("Search(%q) on legacy index failed: %v", query, err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("Search(%q) on legacy index returned wrong rows: %#v", query, results)
+		}
+		for _, result := range results {
+			if result["_src"] != "legacy.log" {
+				t.Fatalf("Search(%q) on legacy index returned wrong source: %#v", query, result)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- disable Bleve's duplicated `_all` composite index, text term vectors, and unused scoring norms
- store numeric fields with one sortable term instead of Bleve's 16 legacy trie terms
- rewrite all-field, phrase, and numeric queries at runtime to preserve existing search behavior
- preserve independent dynamic fields for each ingested source and explicitly scope source filters to `_src`
- keep existing Bleve indices readable and allow optimized documents to append to legacy shards
- add multi-source/legacy compatibility tests and reproducible index-size benchmarks

## Compatibility and risk controls

- stored fields, API responses, daily shard layout, retention, listing, and deletion behavior are unchanged
- dynamic mappings remain enabled, so sources with different schemas retain separate fields without leakage
- phrase queries use inverted-index candidates and verify against stored values after term vectors are removed
- numeric equality/range queries use the sortable shift-0 term that exists in both legacy and optimized indices
- optimized documents strip legacy `_all` composites even when appended to an existing shard
- broad numeric-range and phrase-query performance characteristics can differ, but result behavior is covered by tests

## Benchmark

100 MiB dense-log benchmark on the same Apple M4 machine:

| Version | Index size | Index/raw | Documents | Ingest time |
|---|---:|---:|---:|---:|
| `main` | 714.8 MiB | 7.148x | 386,156 | ~36.05s |
| this branch | 333.4 MiB | 3.334x | 386,156 | ~16.59s |

**Index-size reduction: 53.4% (381.4 MiB saved).**

The 365-day-spread benchmark improves by 31.2%; fixed per-day shard overhead dominates that workload, and this change intentionally leaves daily sharding unchanged to avoid affecting retention and date APIs.

## Validation

- `go test ./pkg/storage -count=1`
- `go test -race ./pkg/storage -count=1`
- `go vet ./...`
- local backend/frontend smoke test
- `npm run test:e2e`: 30 passed; all three-file ingestion checks passed. Two unrelated checks fail because the obsolete `/api/v1/ai/status` endpoint is not registered.
- public API verification confirms nginx and PostgreSQL sources retain disjoint fields, source filters do not leak, and field/numeric searches return the correct source

`go test ./... -count=1` retains one pre-existing unrelated handler failure: `TestHandleGrokPatterns_UnsupportedMethod` expects 405 but receives 400.