### PR TITLE
fix: bump golang backend builder version to make it work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Build the backend
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.26.5-alpine AS backend-builder
 WORKDIR /app/backend
 
 # Copy Go module files first for better caching


### PR DESCRIPTION
Fixes the following error while trying to do `docker buildx`:

```
 > [backend-builder 4/8] RUN go mod download:
0.130 go: go.mod requires go >= 1.25.11 (running go 1.24.13; GOTOOLCHAIN=local)
------
Dockerfile:21
--------------------
  19 |     # Copy Go module files first for better caching
  20 |     COPY backend/go.mod backend/go.sum ./
  21 | >>> RUN go mod download
  22 |
  23 |     # Create the directory structure for static files
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```