### PR TITLE
feat: bound and cancel large-file imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For Linux, Windows, Docker, source builds, storage locations, and the macOS app 
 - [Timestamp Resolution](docs/timestamp-resolution.md): how LogSonic derives real timestamps and when to override.
 - [Development](docs/development.md): local backend/frontend setup, tests, E2E, and Swagger generation.
 - [Architecture](docs/Architecture.md): backend, frontend, storage, and MCP architecture.
+- [Production Readiness Plan](docs/production-readiness-plan.md): bounded import and search, automated releases, secure self-update, rollout gates, and deferred hardening.
 - [MCP Setup](mcp/README.md): configure Claude Desktop, Cursor, Windsurf, or another MCP client.
 - [Agent Playbook](mcp/SKILLS.md): query patterns and workflow guidance for AI clients.
 

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -237,7 +237,59 @@ const docTemplate = `{
                 }
             }
         },
-        "/ingest": {
+        "/ingest/end": {
+            "post": {
+                "description": "End the specified log ingest session and cleanup its resources",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ingest"
+                ],
+                "summary": "End log ingest session",
+                "parameters": [
+                    {
+                        "description": "Session end request with session_id",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.IngestRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.IngestResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ingest/logs": {
             "post": {
                 "description": "Ingest log data using existing Grok patterns and store them into the index",
                 "consumes": [
@@ -274,48 +326,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/types.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/ingest/end": {
-            "post": {
-                "description": "End the specified log ingest session and cleanup its resources",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "ingest"
-                ],
-                "summary": "End log ingest session",
-                "parameters": [
-                    {
-                        "description": "Session end request with session_id",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.IngestRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.IngestResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
+                    "413": {
+                        "description": "Request Entity Too Large",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -362,6 +374,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -1290,6 +1308,14 @@ const docTemplate = `{
                     "type": "object",
                     "additionalProperties": true
                 },
+                "multiline": {
+                    "description": "Multiline configures folding of physical lines into logical log\nrecords before pattern matching, for formats where a single log\nstatement spans multiple lines (stack traces, multi-line JSON,\netc). Nil/disabled preserves the historical one-line-per-record\nbehaviour. Folding is applied on /parse (including autosuggest)\nas well as ingest and live tail.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.MultilineConfig"
+                        }
+                    ]
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1399,6 +1425,29 @@ const docTemplate = `{
                 }
             }
         },
+        "types.MultilineConfig": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "header_pattern": {
+                    "description": "HeaderPattern is a regular expression; required when Mode==\"header\".\nA line matching it starts a new record, everything else is folded\ninto the preceding record. Continuation lines are joined with\nspaces (log2grok's JoinMultilineStrings behaviour).",
+                    "type": "string"
+                },
+                "max_bytes": {
+                    "type": "integer"
+                },
+                "max_lines": {
+                    "description": "MaxLines caps continuation lines folded into one record (default\n100). MaxBytes caps the folded record's byte length (default 1MiB).",
+                    "type": "integer"
+                },
+                "mode": {
+                    "description": "\"header\" | \"indent\"",
+                    "type": "string"
+                }
+            }
+        },
         "types.ParseRequest": {
             "type": "object",
             "properties": {
@@ -1481,6 +1530,14 @@ const docTemplate = `{
                 "combined_coverage": {
                     "description": "CombinedCoverage is the fraction of input lines covered by the union\nof all returned patterns (0.0–1.0). It only differs from\nResults[0].Coverage when a multi-pattern set was requested (Multi)\nand more than one pattern was returned. Omitted for single-pattern\nresponses.",
                     "type": "number"
+                },
+                "multiline": {
+                    "description": "Multiline is the folding config used for this suggestion. Set when\nthe caller supplied one, or when /parse auto-detected a common\ncontinuation style (syslog / ISO 8601 / indent) because folding\nproduced a better library match than treating each physical line\nas its own record.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.MultilineConfig"
+                        }
+                    ]
                 },
                 "results": {
                     "type": "array",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -231,7 +231,59 @@
                 }
             }
         },
-        "/ingest": {
+        "/ingest/end": {
+            "post": {
+                "description": "End the specified log ingest session and cleanup its resources",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ingest"
+                ],
+                "summary": "End log ingest session",
+                "parameters": [
+                    {
+                        "description": "Session end request with session_id",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.IngestRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.IngestResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ingest/logs": {
             "post": {
                 "description": "Ingest log data using existing Grok patterns and store them into the index",
                 "consumes": [
@@ -268,48 +320,8 @@
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/types.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/ingest/end": {
-            "post": {
-                "description": "End the specified log ingest session and cleanup its resources",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "ingest"
-                ],
-                "summary": "End log ingest session",
-                "parameters": [
-                    {
-                        "description": "Session end request with session_id",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.IngestRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.IngestResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
+                    "413": {
+                        "description": "Request Entity Too Large",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -356,6 +368,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.ErrorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
                         "schema": {
                             "$ref": "#/definitions/types.ErrorResponse"
                         }
@@ -1284,6 +1302,14 @@
                     "type": "object",
                     "additionalProperties": true
                 },
+                "multiline": {
+                    "description": "Multiline configures folding of physical lines into logical log\nrecords before pattern matching, for formats where a single log\nstatement spans multiple lines (stack traces, multi-line JSON,\netc). Nil/disabled preserves the historical one-line-per-record\nbehaviour. Folding is applied on /parse (including autosuggest)\nas well as ingest and live tail.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.MultilineConfig"
+                        }
+                    ]
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1393,6 +1419,29 @@
                 }
             }
         },
+        "types.MultilineConfig": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "header_pattern": {
+                    "description": "HeaderPattern is a regular expression; required when Mode==\"header\".\nA line matching it starts a new record, everything else is folded\ninto the preceding record. Continuation lines are joined with\nspaces (log2grok's JoinMultilineStrings behaviour).",
+                    "type": "string"
+                },
+                "max_bytes": {
+                    "type": "integer"
+                },
+                "max_lines": {
+                    "description": "MaxLines caps continuation lines folded into one record (default\n100). MaxBytes caps the folded record's byte length (default 1MiB).",
+                    "type": "integer"
+                },
+                "mode": {
+                    "description": "\"header\" | \"indent\"",
+                    "type": "string"
+                }
+            }
+        },
         "types.ParseRequest": {
             "type": "object",
             "properties": {
@@ -1475,6 +1524,14 @@
                 "combined_coverage": {
                     "description": "CombinedCoverage is the fraction of input lines covered by the union\nof all returned patterns (0.0–1.0). It only differs from\nResults[0].Coverage when a multi-pattern set was requested (Multi)\nand more than one pattern was returned. Omitted for single-pattern\nresponses.",
                     "type": "number"
+                },
+                "multiline": {
+                    "description": "Multiline is the folding config used for this suggestion. Set when\nthe caller supplied one, or when /parse auto-detected a common\ncontinuation style (syslog / ISO 8601 / indent) because folding\nproduced a better library match than treating each physical line\nas its own record.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.MultilineConfig"
+                        }
+                    ]
                 },
                 "results": {
                     "type": "array",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -295,6 +295,16 @@ definitions:
           Meta contains additional fields to be added to each log entry.
           These fields are merged directly into the JSON output for each log.
         type: object
+      multiline:
+        allOf:
+        - $ref: '#/definitions/types.MultilineConfig'
+        description: |-
+          Multiline configures folding of physical lines into logical log
+          records before pattern matching, for formats where a single log
+          statement spans multiple lines (stack traces, multi-line JSON,
+          etc). Nil/disabled preserves the historical one-line-per-record
+          behaviour. Folding is applied on /parse (including autosuggest)
+          as well as ingest and live tail.
       name:
         type: string
       pattern:
@@ -372,6 +382,28 @@ definitions:
       total_count:
         type: integer
     type: object
+  types.MultilineConfig:
+    properties:
+      enabled:
+        type: boolean
+      header_pattern:
+        description: |-
+          HeaderPattern is a regular expression; required when Mode=="header".
+          A line matching it starts a new record, everything else is folded
+          into the preceding record. Continuation lines are joined with
+          spaces (log2grok's JoinMultilineStrings behaviour).
+        type: string
+      max_bytes:
+        type: integer
+      max_lines:
+        description: |-
+          MaxLines caps continuation lines folded into one record (default
+          100). MaxBytes caps the folded record's byte length (default 1MiB).
+        type: integer
+      mode:
+        description: '"header" | "indent"'
+        type: string
+    type: object
   types.ParseRequest:
     properties:
       custom_patterns:
@@ -447,6 +479,15 @@ definitions:
           and more than one pattern was returned. Omitted for single-pattern
           responses.
         type: number
+      multiline:
+        allOf:
+        - $ref: '#/definitions/types.MultilineConfig'
+        description: |-
+          Multiline is the folding config used for this suggestion. Set when
+          the caller supplied one, or when /parse auto-detected a common
+          continuation style (syslog / ISO 8601 / indent) because folding
+          produced a better library match than treating each physical line
+          as its own record.
       results:
         items:
           $ref: '#/definitions/types.AutosuggestResult'
@@ -757,37 +798,6 @@ paths:
       summary: Get system and storage information
       tags:
       - system
-  /ingest:
-    post:
-      consumes:
-      - application/json
-      description: Ingest log data using existing Grok patterns and store them into
-        the index
-      parameters:
-      - description: Log ingest request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.IngestRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.IngestResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/types.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/types.ErrorResponse'
-      summary: Ingest log data
-      tags:
-      - ingest
   /ingest/end:
     post:
       consumes:
@@ -811,11 +821,50 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/types.ErrorResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.ErrorResponse'
       summary: End log ingest session
+      tags:
+      - ingest
+  /ingest/logs:
+    post:
+      consumes:
+      - application/json
+      description: Ingest log data using existing Grok patterns and store them into
+        the index
+      parameters:
+      - description: Log ingest request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.IngestRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.IngestResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+      summary: Ingest log data
       tags:
       - ingest
   /ingest/start:
@@ -840,6 +889,10 @@ paths:
             $ref: '#/definitions/types.IngestResponse'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/types.ErrorResponse'
+        "413":
+          description: Request Entity Too Large
           schema:
             $ref: '#/definitions/types.ErrorResponse'
         "500":

--- a/backend/pkg/server/handlers/ingest.go
+++ b/backend/pkg/server/handlers/ingest.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"logsonic/pkg/types"
 	"net/http"
@@ -15,9 +16,12 @@ import (
 )
 
 const (
-	DefaultPatternName = "DEFAULT_PATTERN"
-	DefaultPattern     = "%{GREEDYDATA:message}"
-	SessionTimeout     = 60 * time.Minute
+	DefaultPatternName    = "DEFAULT_PATTERN"
+	DefaultPattern        = "%{GREEDYDATA:message}"
+	SessionTimeout        = 60 * time.Minute
+	MaxIngestRequestBytes = 16 * 1024 * 1024
+	MaxIngestLines        = 10_000
+	MaxIngestLineBytes    = 2 * 1024 * 1024
 )
 
 var defaultIngestSessionOptions = types.IngestSessionOptions{
@@ -37,6 +41,7 @@ var defaultIngestSessionOptions = types.IngestSessionOptions{
 type IngestSession struct {
 	Options      types.IngestSessionOptions
 	CreationTime time.Time
+	LastActivity time.Time
 	Decoder      *l2g.Decoder
 	// Seq is a session-wide monotonic line counter shared across every
 	// /ingest call for this session (the session is copied by value out
@@ -53,6 +58,59 @@ type IngestSession struct {
 var sessionMap = make(map[string]IngestSession)
 var sessionMapMutex = &sync.RWMutex{}
 
+func isRequestBodyTooLarge(err error) bool {
+	var maxBytesError *http.MaxBytesError
+	return errors.As(err, &maxBytesError)
+}
+
+func writeIngestBodyError(w http.ResponseWriter, err error) {
+	status := http.StatusBadRequest
+	code := "INVALID_REQUEST"
+	message := "Invalid request body"
+	if isRequestBodyTooLarge(err) {
+		status = http.StatusRequestEntityTooLarge
+		code = "INGEST_BODY_TOO_LARGE"
+		message = "Ingest request body exceeds the configured limit"
+	}
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(types.ErrorResponse{
+		Status:  "error",
+		Error:   message,
+		Code:    code,
+		Details: err.Error(),
+	})
+}
+
+func decodeIngestJSON(w http.ResponseWriter, r *http.Request, target interface{}) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestRequestBytes)
+	if err := json.NewDecoder(r.Body).Decode(target); err != nil {
+		writeIngestBodyError(w, err)
+		return false
+	}
+	return true
+}
+
+func writeIngestLimitError(w http.ResponseWriter, message string) {
+	w.WriteHeader(http.StatusRequestEntityTooLarge)
+	json.NewEncoder(w).Encode(types.ErrorResponse{
+		Status: "error",
+		Error:  message,
+		Code:   "INGEST_LIMIT_EXCEEDED",
+	})
+}
+
+func validateIngestLogs(logs []string) (string, bool) {
+	if len(logs) > MaxIngestLines {
+		return "Ingest request contains too many log lines", false
+	}
+	for _, line := range logs {
+		if len(line) > MaxIngestLineBytes {
+			return "A log line exceeds the configured size limit", false
+		}
+	}
+	return "", true
+}
+
 // @Summary Ingest log data
 // @Description Ingest log data using existing Grok patterns and store them into the index
 // @Tags ingest
@@ -61,8 +119,9 @@ var sessionMapMutex = &sync.RWMutex{}
 // @Param request body types.IngestRequest true "Log ingest request"
 // @Success 200 {object} types.IngestResponse
 // @Failure 400 {object} types.ErrorResponse
+// @Failure 413 {object} types.ErrorResponse
 // @Failure 500 {object} types.ErrorResponse
-// @Router /ingest [post]
+// @Router /ingest/logs [post]
 func (h *Services) HandleIngest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -77,24 +136,29 @@ func (h *Services) HandleIngest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req types.IngestRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(types.ErrorResponse{
-			Status:  "error",
-			Error:   "Invalid request body",
-			Code:    "INVALID_REQUEST",
-			Details: err.Error(),
-		})
+	if !decodeIngestJSON(w, r, &req) {
 		return
 	}
 
-	sessionMapMutex.RLock()
+	if message, ok := validateIngestLogs(req.Logs); !ok {
+		writeIngestLimitError(w, message)
+		return
+	}
+
+	// Mark the request as activity while atomically taking the session
+	// snapshot. This prevents the cleanup sweep from expiring an active
+	// upload between session lookup and decoding/storage.
+	sessionMapMutex.Lock()
 	session, exists := sessionMap[req.SessionID]
+	if exists {
+		session.LastActivity = time.Now()
+		sessionMap[req.SessionID] = session
+	}
 	sessionOptions := session.Options
 	sessionDecoder := session.Decoder
 	sessionSeq := session.Seq
 	sessionMultiline := session.Multiline
-	sessionMapMutex.RUnlock()
+	sessionMapMutex.Unlock()
 
 	if !exists || req.SessionID == "" {
 		w.WriteHeader(http.StatusBadRequest)
@@ -171,6 +235,7 @@ func (h *Services) HandleIngest(w http.ResponseWriter, r *http.Request) {
 // @Param request body types.IngestSessionOptions true "Log ingest session start request"
 // @Success 200 {object} types.IngestResponse
 // @Failure 400 {object} types.ErrorResponse
+// @Failure 413 {object} types.ErrorResponse
 // @Failure 500 {object} types.ErrorResponse
 // @Router /ingest/start [post]
 func (h *Services) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
@@ -187,14 +252,7 @@ func (h *Services) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req types.IngestSessionOptions
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(types.ErrorResponse{
-			Status:  "error",
-			Error:   "Invalid request body",
-			Code:    "INVALID_REQUEST",
-			Details: err.Error(),
-		})
+	if !decodeIngestJSON(w, r, &req) {
 		return
 	}
 
@@ -244,6 +302,7 @@ func (h *Services) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sessionID := uuid.New().String()
+	now := time.Now()
 
 	sessionOptions := types.IngestSessionOptions{
 		Name:            req.Name,
@@ -265,7 +324,8 @@ func (h *Services) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
 	sessionMapMutex.Lock()
 	sessionMap[sessionID] = IngestSession{
 		Options:      sessionOptions,
-		CreationTime: time.Now(),
+		CreationTime: now,
+		LastActivity: now,
 		Decoder:      dec,
 		Seq:          new(atomic.Int64),
 		Multiline:    multiline,
@@ -286,6 +346,7 @@ func (h *Services) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
 // @Param request body types.IngestRequest true "Session end request with session_id"
 // @Success 200 {object} types.IngestResponse
 // @Failure 400 {object} types.ErrorResponse
+// @Failure 413 {object} types.ErrorResponse
 // @Failure 500 {object} types.ErrorResponse
 // @Router /ingest/end [post]
 func (h *Services) HandleIngestEnd(w http.ResponseWriter, r *http.Request) {
@@ -301,8 +362,13 @@ func (h *Services) HandleIngestEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestRequestBytes)
 	var req types.IngestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeIngestBodyError(w, err)
+			return
+		}
 		json.NewEncoder(w).Encode(types.IngestResponse{
 			Status: "success",
 		})
@@ -358,7 +424,13 @@ func expireStaleSessions(now time.Time, h *Services) {
 	var expired []expiredSession
 	sessionMapMutex.Lock()
 	for id, session := range sessionMap {
-		if now.Sub(session.CreationTime) > SessionTimeout {
+		lastActivity := session.LastActivity
+		if lastActivity.IsZero() {
+			// Preserve cleanup behavior for sessions created by older binaries
+			// or tests that do not have LastActivity populated.
+			lastActivity = session.CreationTime
+		}
+		if now.Sub(lastActivity) > SessionTimeout {
 			expired = append(expired, expiredSession{id: id, session: session})
 			delete(sessionMap, id)
 		}

--- a/backend/pkg/server/handlers/ingest_limits_test.go
+++ b/backend/pkg/server/handlers/ingest_limits_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"logsonic/pkg/types"
+)
+
+func addTestIngestSession(t *testing.T, id string, lastActivity time.Time) {
+	t.Helper()
+	sessionMapMutex.Lock()
+	sessionMap[id] = IngestSession{
+		CreationTime: lastActivity,
+		LastActivity: lastActivity,
+	}
+	sessionMapMutex.Unlock()
+	t.Cleanup(func() {
+		sessionMapMutex.Lock()
+		delete(sessionMap, id)
+		sessionMapMutex.Unlock()
+	})
+}
+
+func TestHandleIngest_RejectsTooManyLines(t *testing.T) {
+	h, store := setupHandler(t)
+	addTestIngestSession(t, "line-limit", time.Now())
+
+	logs := make([]string, MaxIngestLines+1)
+	for i := range logs {
+		logs[i] = "line"
+	}
+	body, err := json.Marshal(types.IngestRequest{SessionID: "line-limit", Logs: logs})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/logs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleIngest(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(store.logs) != 0 {
+		t.Fatalf("limit rejection should not store logs, got %d", len(store.logs))
+	}
+	var response types.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != "INGEST_LIMIT_EXCEEDED" {
+		t.Fatalf("expected INGEST_LIMIT_EXCEEDED, got %q", response.Code)
+	}
+}
+
+func TestHandleIngest_RejectsOversizedLine(t *testing.T) {
+	h, store := setupHandler(t)
+	addTestIngestSession(t, "line-size-limit", time.Now())
+
+	body, err := json.Marshal(types.IngestRequest{
+		SessionID: "line-size-limit",
+		Logs:      []string{strings.Repeat("x", MaxIngestLineBytes+1)},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/logs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleIngest(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(store.logs) != 0 {
+		t.Fatalf("limit rejection should not store logs, got %d", len(store.logs))
+	}
+}
+
+func TestHandleIngest_RejectsOversizedRequestBody(t *testing.T) {
+	h, _ := setupHandler(t)
+	addTestIngestSession(t, "body-size-limit", time.Now())
+
+	// The large JSON string exceeds MaxIngestRequestBytes before the decoder
+	// can materialize an IngestRequest.
+	body := []byte(`{"session_id":"body-size-limit","logs":["`)
+	body = append(body, strings.Repeat("x", MaxIngestRequestBytes)...)
+	body = append(body, []byte(`"]}`)...)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/logs", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleIngest(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	var response types.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != "INGEST_BODY_TOO_LARGE" {
+		t.Fatalf("expected INGEST_BODY_TOO_LARGE, got %q", response.Code)
+	}
+}
+
+func TestExpireStaleSessions_UsesLastActivity(t *testing.T) {
+	h, _ := setupHandler(t)
+	id := "active-session"
+	creation := time.Now().Add(-SessionTimeout - time.Minute)
+	addTestIngestSession(t, id, creation)
+
+	sessionMapMutex.Lock()
+	session := sessionMap[id]
+	session.LastActivity = time.Now()
+	sessionMap[id] = session
+	sessionMapMutex.Unlock()
+
+	expireStaleSessions(time.Now(), h)
+
+	sessionMapMutex.RLock()
+	_, exists := sessionMap[id]
+	sessionMapMutex.RUnlock()
+	if !exists {
+		t.Fatal("active session was expired based on creation time")
+	}
+
+	sessionMapMutex.Lock()
+	session = sessionMap[id]
+	session.LastActivity = time.Now().Add(-SessionTimeout - time.Minute)
+	sessionMap[id] = session
+	sessionMapMutex.Unlock()
+	expireStaleSessions(time.Now(), h)
+
+	sessionMapMutex.RLock()
+	_, exists = sessionMap[id]
+	sessionMapMutex.RUnlock()
+	if exists {
+		t.Fatal("inactive session was not expired")
+	}
+}

--- a/backend/pkg/server/handlers/multiline_test.go
+++ b/backend/pkg/server/handlers/multiline_test.go
@@ -448,6 +448,7 @@ func TestExpireStaleSessions_FlushesPendingMultiline(t *testing.T) {
 		t.Fatal("session missing after ingest")
 	}
 	session.CreationTime = time.Now().Add(-SessionTimeout - time.Minute)
+	session.LastActivity = session.CreationTime
 	sessionMap[sessionID] = session
 	sessionMapMutex.Unlock()
 

--- a/frontend/src/components/Import/LocalFileImport/FileSelection.tsx
+++ b/frontend/src/components/Import/LocalFileImport/FileSelection.tsx
@@ -6,7 +6,7 @@ import { useFileSelectionService } from './FileSelectionService';
 
 const ACCEPTED_TYPES = ['.log', '.txt', '.json'];
 const ACCEPTED_MIME = ['text/plain', 'application/json'];
-const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
+const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5 GiB; import itself remains chunked
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -47,7 +47,7 @@ export const FileSelection: FC<LogSourceProvider> = ({
         continue;
       }
       if (file.size > MAX_FILE_SIZE) {
-        errors.push(`"${file.name}" exceeds the 500 MB size limit`);
+        errors.push(`"${file.name}" exceeds the 5 GiB size limit`);
         continue;
       }
       if (file.size === 0) {
@@ -247,7 +247,7 @@ export const FileSelection: FC<LogSourceProvider> = ({
               >
                 .json
               </span>
-              <span style={{ color: 'var(--ls-text-3)' }}>· up to 500 MB each</span>
+              <span style={{ color: 'var(--ls-text-3)' }}>· up to 5 GiB each</span>
             </span>
             <span style={{ marginTop: 8, fontSize: 11.5, color: 'var(--ls-text-3)' }}>
               LogSonic auto-detects the best Grok pattern for each file.

--- a/frontend/src/components/Import/LocalFileImport/FileSelectionService.test.ts
+++ b/frontend/src/components/Import/LocalFileImport/FileSelectionService.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PHYSICAL_LINE_BYTES,
+  READ_RANGE_BYTES,
+  readFilePreview,
+  streamFileChunks,
+} from "./FileSelectionService";
+
+describe("streamFileChunks", () => {
+  it("preserves UTF-8, CRLF boundaries, empty-line behavior, and order", async () => {
+    // Put the first byte of a four-byte code point at the end of the first
+    // read range, while keeping every physical line well below the limit.
+    const prefix = "a\n".repeat(Math.floor((READ_RANGE_BYTES - 1) / 2));
+    const file = new File([`${prefix}a🙂\r\nsecond\n\nthird`], "logs.txt");
+    const chunks: string[][] = [];
+
+    await streamFileChunks(file, 2, async ({ lines }) => {
+      chunks.push(lines);
+    });
+
+    const lines = chunks.flat();
+    expect(lines.slice(-3)).toEqual(["a🙂", "second", "third"]);
+    expect(lines.length).toBe(Math.floor((READ_RANGE_BYTES - 1) / 2) + 3);
+    expect(chunks[0]).toHaveLength(2);
+  });
+
+  it("reports byte progress and keeps one request below the client chunk cap", async () => {
+    const file = new File(["one\ntwo\nthree\nfour\n"], "logs.txt");
+    const progress: Array<{ bytesRead: number; totalBytes: number; count: number }> = [];
+
+    await streamFileChunks(file, 2, async ({ lines, bytesRead, totalBytes }) => {
+      progress.push({ bytesRead, totalBytes, count: lines.length });
+    });
+
+    expect(progress).toEqual([
+      { bytesRead: file.size, totalBytes: file.size, count: 2 },
+      { bytesRead: file.size, totalBytes: file.size, count: 2 },
+    ]);
+  });
+
+  it("stops on cancellation before reading the next range", async () => {
+    const file = new File(["line\n".repeat(READ_RANGE_BYTES)], "logs.txt");
+    const controller = new AbortController();
+    let callbacks = 0;
+
+    await expect(streamFileChunks(file, 1, async () => {
+      callbacks += 1;
+      controller.abort();
+    }, controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(callbacks).toBe(1);
+  });
+
+  it("rejects a physical line above the bounded line size", async () => {
+    const file = new File(["x".repeat(MAX_PHYSICAL_LINE_BYTES + 1)], "logs.txt");
+
+    await expect(streamFileChunks(file, 10, async () => undefined))
+      .rejects.toThrow("2 MiB limit");
+  });
+});
+
+describe("readFilePreview", () => {
+  it("returns at most the first 100 non-empty lines", async () => {
+    const file = new File([Array.from({ length: 150 }, (_, i) => `line-${i}`).join("\n")], "logs.txt");
+
+    const preview = await readFilePreview(file);
+
+    expect(preview.lines).toHaveLength(100);
+    expect(preview.lines[0]).toBe("line-0");
+    expect(preview.lines[99]).toBe("line-99");
+    expect(preview.approxLines).toBe(150);
+  });
+
+  it("includes a short file without a trailing newline", async () => {
+    const preview = await readFilePreview(new File(["single line"], "logs.txt"));
+
+    expect(preview).toEqual({ lines: ["single line"], approxLines: 1 });
+  });
+
+  it("strips a UTF-8 BOM from the first line", async () => {
+    const body = new TextEncoder().encode("error started\nsecond");
+    const bytes = new Uint8Array(3 + body.length);
+    bytes.set([0xEF, 0xBB, 0xBF], 0);
+    bytes.set(body, 3);
+    const file = new File([bytes], "logs.txt");
+
+    const preview = await readFilePreview(file);
+    expect(preview.lines).toEqual(["error started", "second"]);
+
+    const chunks: string[] = [];
+    await streamFileChunks(file, 10, async ({ lines }) => {
+      chunks.push(...lines);
+    });
+    expect(chunks).toEqual(["error started", "second"]);
+  });
+});

--- a/frontend/src/components/Import/LocalFileImport/FileSelectionService.test.ts
+++ b/frontend/src/components/Import/LocalFileImport/FileSelectionService.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MAX_CHUNK_BYTES,
   MAX_PHYSICAL_LINE_BYTES,
   READ_RANGE_BYTES,
   readFilePreview,
@@ -56,6 +57,28 @@ describe("streamFileChunks", () => {
 
     await expect(streamFileChunks(file, 10, async () => undefined))
       .rejects.toThrow("2 MiB limit");
+  });
+
+  it("rejects an escaped line that cannot fit in one request", async () => {
+    const file = new File(["\0".repeat(1.5 * 1024 * 1024)], "logs.txt");
+
+    await expect(streamFileChunks(file, 10, async () => undefined))
+      .rejects.toThrow("cannot fit within the 8 MiB request limit");
+  });
+
+  it("keeps an escaped line that fits below the serialized request cap", async () => {
+    const file = new File(["\0".repeat(1024 * 1024)], "logs.txt");
+    const encoder = new TextEncoder();
+    let bodyBytes = 0;
+
+    await streamFileChunks(file, 10, async ({ lines }) => {
+      bodyBytes = encoder.encode(JSON.stringify({
+        logs: lines,
+        session_id: "0".repeat(36),
+      })).byteLength;
+    });
+
+    expect(bodyBytes).toBeLessThanOrEqual(MAX_CHUNK_BYTES);
   });
 });
 

--- a/frontend/src/components/Import/LocalFileImport/FileSelectionService.ts
+++ b/frontend/src/components/Import/LocalFileImport/FileSelectionService.ts
@@ -18,6 +18,32 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw abortError();
 }
 
+const jsonEscapePattern = new RegExp(
+  '["\\\\' + String.fromCharCode(0) + '-' + String.fromCharCode(0x1F) + ']',
+);
+const surrogatePattern = /[\uD800-\uDFFF]/;
+const exactJsonSizeThreshold = 256 * 1024;
+
+function serializedJsonStringByteLength(
+  text: string,
+  utf8Bytes: number,
+  encoder: TextEncoder,
+): number {
+  if (!jsonEscapePattern.test(text) && !surrogatePattern.test(text)) {
+    return utf8Bytes + 2; // surrounding quotes
+  }
+
+  // Avoid materializing a potentially 6x-expanded JSON string for large
+  // escaped lines. The bound is exact for ASCII control characters and a
+  // safe upper bound for all other UTF-16 input. It only makes chunking more
+  // conservative; the request remains below the configured limit.
+  if (text.length > exactJsonSizeThreshold) {
+    return text.length * 6 + 2;
+  }
+
+  return encoder.encode(JSON.stringify(text)).byteLength;
+}
+
 function splitCompleteLines(text: string): { lines: string[]; remainder: string } {
   const parts = text.split("\n");
   const remainder = parts.pop() ?? "";
@@ -70,7 +96,7 @@ export async function streamFileChunks(
   const encoder = new TextEncoder();
   const sessionIDPlaceholder = "0".repeat(36);
   const emptyBody = JSON.stringify({ logs: [], session_id: sessionIDPlaceholder });
-  const bodyPrefixBytes = encoder.encode(emptyBody).byteLength - encoder.encode("[]").byteLength;
+  const bodyPrefixBytes = encoder.encode(emptyBody).byteLength - 2;
   let pendingBodyBytes = bodyPrefixBytes;
 
   while (byteOffset < file.size) {
@@ -96,7 +122,10 @@ export async function streamFileChunks(
       if (lineBytes > MAX_PHYSICAL_LINE_BYTES) {
         throw new Error(`A log line exceeds the ${MAX_PHYSICAL_LINE_BYTES / (1024 * 1024)} MiB limit`);
       }
-      const serializedLineBytes = encoder.encode(JSON.stringify(line)).byteLength;
+      const serializedLineBytes = serializedJsonStringByteLength(line, lineBytes, encoder);
+      if (bodyPrefixBytes + serializedLineBytes > MAX_CHUNK_BYTES) {
+        throw new Error(`A log line cannot fit within the ${MAX_CHUNK_BYTES / (1024 * 1024)} MiB request limit`);
+      }
       const nextBodyBytes = pendingBodyBytes + serializedLineBytes + (pendingLines.length > 0 ? 1 : 0);
       if (pendingLines.length > 0 && (
         pendingLines.length >= chunkSize || nextBodyBytes > bodyPrefixBytes + MAX_CHUNK_BYTES
@@ -122,7 +151,10 @@ export async function streamFileChunks(
     if (lineBytes > MAX_PHYSICAL_LINE_BYTES) {
       throw new Error(`A log line exceeds the ${MAX_PHYSICAL_LINE_BYTES / (1024 * 1024)} MiB limit`);
     }
-    const serializedLineBytes = encoder.encode(JSON.stringify(remainder)).byteLength;
+    const serializedLineBytes = serializedJsonStringByteLength(remainder, lineBytes, encoder);
+    if (bodyPrefixBytes + serializedLineBytes > MAX_CHUNK_BYTES) {
+      throw new Error(`A log line cannot fit within the ${MAX_CHUNK_BYTES / (1024 * 1024)} MiB request limit`);
+    }
     if (pendingLines.length > 0 && (
       pendingLines.length >= chunkSize
       || pendingBodyBytes + serializedLineBytes + 1 > bodyPrefixBytes + MAX_CHUNK_BYTES

--- a/frontend/src/components/Import/LocalFileImport/FileSelectionService.ts
+++ b/frontend/src/components/Import/LocalFileImport/FileSelectionService.ts
@@ -1,70 +1,167 @@
 import { useImportStore } from "@/stores/useImportStore";
-import type { LogSourceProviderService } from "../types";
+import type { FileImportChunk, LogSourceProviderService } from "../types";
 
+export const PREVIEW_BYTES = 1 * 1024 * 1024;
+export const READ_RANGE_BYTES = 4 * 1024 * 1024;
+export const MAX_CHUNK_BYTES = 8 * 1024 * 1024;
+export const MAX_PHYSICAL_LINE_BYTES = 2 * 1024 * 1024;
 
+const utf8Decoder = () => new TextDecoder("utf-8");
 
-export const useFileSelectionService = () : LogSourceProviderService => {
-  const importStore = useImportStore();    
+function stripLeadingUtf8Bom(text: string): string {
+  return text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+}
+
+const abortError = () => new DOMException("The file import was cancelled", "AbortError");
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError();
+}
+
+function splitCompleteLines(text: string): { lines: string[]; remainder: string } {
+  const parts = text.split("\n");
+  const remainder = parts.pop() ?? "";
+  return {
+    // Preserve the historical import behavior: empty physical lines are not
+    // sent to the ingest API. A lone CR is retained as content, while CRLF
+    // is normalized to the same line representation as the old split regex.
+    lines: parts.map((line) => line.endsWith("\r") ? line.slice(0, -1) : line),
+    remainder,
+  };
+}
+
+function previewLineCount(lines: string[], remainder: string, bytesRead: number, totalBytes: number): number {
+  const nonEmptyLines = lines.filter((line) => line.length > 0).length;
+  if (totalBytes <= bytesRead || bytesRead === 0 || nonEmptyLines === 0) {
+    return nonEmptyLines + (remainder.length > 0 ? 1 : 0);
+  }
+  return Math.max(1, Math.ceil(nonEmptyLines * totalBytes / bytesRead));
+}
+
+export async function readFilePreview(file: File): Promise<{ lines: string[]; approxLines: number }> {
+  const bytesRead = Math.min(file.size, PREVIEW_BYTES);
+  const buffer = await file.slice(0, bytesRead).arrayBuffer();
+  const text = stripLeadingUtf8Bom(utf8Decoder().decode(buffer));
+  const split = splitCompleteLines(text);
+  const lines = bytesRead === file.size && split.remainder.length > 0
+    ? [...split.lines, split.remainder]
+    : split.lines;
+  return {
+    lines: lines.filter((line) => line.length > 0).slice(0, 100),
+    approxLines: previewLineCount(split.lines, split.remainder, bytesRead, file.size),
+  };
+}
+
+export async function streamFileChunks(
+  file: File,
+  chunkSize: number,
+  callback: (chunk: FileImportChunk) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new Error("File chunk size must be a positive integer");
+  }
+
+  const decoder = utf8Decoder();
+  let byteOffset = 0;
+  let remainder = "";
+  let pendingLines: string[] = [];
+  let strippedLeadingBom = false;
+  const encoder = new TextEncoder();
+  const sessionIDPlaceholder = "0".repeat(36);
+  const emptyBody = JSON.stringify({ logs: [], session_id: sessionIDPlaceholder });
+  const bodyPrefixBytes = encoder.encode(emptyBody).byteLength - encoder.encode("[]").byteLength;
+  let pendingBodyBytes = bodyPrefixBytes;
+
+  while (byteOffset < file.size) {
+    throwIfAborted(signal);
+    const nextOffset = Math.min(file.size, byteOffset + READ_RANGE_BYTES);
+    const buffer = await file.slice(byteOffset, nextOffset).arrayBuffer();
+    byteOffset = nextOffset;
+    remainder += decoder.decode(buffer, { stream: byteOffset < file.size });
+    if (!strippedLeadingBom) {
+      remainder = stripLeadingUtf8Bom(remainder);
+      strippedLeadingBom = remainder.length > 0 || byteOffset >= file.size;
+    }
+
+    const split = splitCompleteLines(remainder);
+    remainder = split.remainder;
+    if (encoder.encode(remainder).byteLength > MAX_PHYSICAL_LINE_BYTES) {
+      throw new Error(`A log line exceeds the ${MAX_PHYSICAL_LINE_BYTES / (1024 * 1024)} MiB limit`);
+    }
+    for (const line of split.lines) {
+      throwIfAborted(signal);
+      if (line.length === 0) continue;
+      const lineBytes = encoder.encode(line).byteLength;
+      if (lineBytes > MAX_PHYSICAL_LINE_BYTES) {
+        throw new Error(`A log line exceeds the ${MAX_PHYSICAL_LINE_BYTES / (1024 * 1024)} MiB limit`);
+      }
+      const serializedLineBytes = encoder.encode(JSON.stringify(line)).byteLength;
+      const nextBodyBytes = pendingBodyBytes + serializedLineBytes + (pendingLines.length > 0 ? 1 : 0);
+      if (pendingLines.length > 0 && (
+        pendingLines.length >= chunkSize || nextBodyBytes > bodyPrefixBytes + MAX_CHUNK_BYTES
+      )) {
+        throwIfAborted(signal);
+        const lines = pendingLines;
+        pendingLines = [];
+        pendingBodyBytes = bodyPrefixBytes;
+        await callback({ lines, bytesRead: byteOffset, totalBytes: file.size });
+      }
+      pendingLines.push(line);
+      pendingBodyBytes += serializedLineBytes + (pendingLines.length > 1 ? 1 : 0);
+    }
+  }
+
+  throwIfAborted(signal);
+  remainder += decoder.decode();
+  if (!strippedLeadingBom) {
+    remainder = stripLeadingUtf8Bom(remainder);
+  }
+  if (remainder.length > 0) {
+    const lineBytes = encoder.encode(remainder).byteLength;
+    if (lineBytes > MAX_PHYSICAL_LINE_BYTES) {
+      throw new Error(`A log line exceeds the ${MAX_PHYSICAL_LINE_BYTES / (1024 * 1024)} MiB limit`);
+    }
+    const serializedLineBytes = encoder.encode(JSON.stringify(remainder)).byteLength;
+    if (pendingLines.length > 0 && (
+      pendingLines.length >= chunkSize
+      || pendingBodyBytes + serializedLineBytes + 1 > bodyPrefixBytes + MAX_CHUNK_BYTES
+    )) {
+      throwIfAborted(signal);
+      await callback({ lines: pendingLines, bytesRead: file.size, totalBytes: file.size });
+      pendingLines = [];
+      pendingBodyBytes = bodyPrefixBytes;
+    }
+    pendingLines.push(remainder);
+  }
+
+  if (pendingLines.length > 0) {
+    throwIfAborted(signal);
+    await callback({ lines: pendingLines, bytesRead: file.size, totalBytes: file.size });
+  }
+}
+
+export const useFileSelectionService = (): LogSourceProviderService => {
+  const importStore = useImportStore();
 
   const handleFilePreview = async (filehandle: object, onPreviewReadyCallback: (lines: string[]) => void) => {
-
     const file = filehandle as File;
     importStore.setSelectedFileHandle(file);
-    const reader = new FileReader();
-    reader.onload = async (e) => {
-      const text = e.target?.result as string;
-
-      // Set approx lines
-      const lines = text.split(/\r?\n/).filter(line => line.length > 0);
-      importStore.setApproxLines(lines.length);
-      const preViewLines = lines.slice(0, 100);
-      // TBD check if the file is binary or has no valid delimiter
-      onPreviewReadyCallback(preViewLines);
-      reader.abort();
-    };
-   
-    reader.readAsText(file);
+    const { lines, approxLines } = await readFilePreview(file);
+    importStore.setApproxLines(approxLines);
+    onPreviewReadyCallback(lines);
   };
 
-  const handleFileImport = (filehandle: object, chunkSize: number, callback: (lines: string[], totalLines: number, next: () => void) => Promise<void>) => {  
-    // process data
-    const file = filehandle as File;
-    let currentIndex = 0;
-    return new Promise<void>((resolve, reject) => {
-      console.log("Importing file:", file.name, "with handle:", filehandle);
-      if (file) {
-        const reader = new FileReader();
-        reader.onload = async (e) => {
-          const text = e.target?.result as string;
-          const lines = text.split(/\r?\n/).filter(line => line.length > 0);
-          let totalLines = lines.length;
-
-          const processChunk = async () => {
-            const chunk = lines.slice(currentIndex, currentIndex + chunkSize);
-            await callback(chunk, totalLines, () => {
-              currentIndex += chunkSize;
-              if (currentIndex < totalLines) {
-                processChunk();
-              } else {
-                resolve();
-              }
-            });
-          };  
-          processChunk();
-        };
-        reader.onerror = (e) => {
-          reject(new Error("Error reading file"));
-        };
-        reader.readAsText(file);
-      } else {
-        reject(new Error("No filename or filehandle provided"));
-      }
-    });
-  };
+  const handleFileImport = (
+    filehandle: object,
+    chunkSize: number,
+    callback: (chunk: FileImportChunk) => Promise<void>,
+    signal?: AbortSignal,
+  ) => streamFileChunks(filehandle as File, chunkSize, callback, signal);
 
   return {
     name: "File",
     handleFilePreview,
-    handleFileImport
+    handleFileImport,
   };
 };

--- a/frontend/src/components/Import/UploadSteps/IngestSessionOptions.tsx
+++ b/frontend/src/components/Import/UploadSteps/IngestSessionOptions.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
 import { useImportStore } from '@/stores/useImportStore';
 import { Settings2 } from 'lucide-react';
 import { FC } from 'react';
@@ -87,25 +88,21 @@ export const IngestSessionOptions: FC = () => {
             </AccordionTrigger>
           </CardHeader>
           <AccordionContent>
-            <CardContent className="pt-3 ">
-
-              <div className="grid grid-cols-1 md:grid-cols-6 gap-x-4 gap-y-0 items-end">
-                
-                {/* Column 1: Smart Decoder */}
-                <div className="space-y-1.5 col-span-2">
+            <CardContent className="pt-3">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-12 items-start">
+                <div className="space-y-1.5 min-w-0 sm:col-span-2 lg:col-span-3">
                   <Label htmlFor="smart_decoder" className="text-sm font-medium">Smart Decoder</Label>
                   <div className="h-9 flex items-center">
-                    <Switch 
+                    <Switch
                       id="smart_decoder"
-                      checked={sessionOptionsSmartDecoder || false} 
+                      checked={sessionOptionsSmartDecoder || false}
                       onCheckedChange={(checked) => setSessionOptionSmartDecoder(checked)}
                     />
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">Automatically detects emails, IP addresses and other patterns in your logs</p>
+                  <p className="text-xs text-muted-foreground leading-snug">Automatically detects emails, IP addresses and other patterns in your logs</p>
                 </div>
 
-                {/* Column 2: Timezone */}
-                <div className="space-y-1.5 col-span-1">
+                <div className="space-y-1.5 min-w-0 lg:col-span-3">
                   <Label htmlFor="force_timezone" className="text-sm font-medium">Force Timezone</Label>
                   <TimezoneSelectorCommon
                     selectedTimezone={sessionOptionsTimezone || 'auto'}
@@ -113,28 +110,27 @@ export const IngestSessionOptions: FC = () => {
                     label="Force Timezone"
                     placeholder="Timezone"
                   />
-                  <p className="text-xs text-muted-foreground mt-1">Force the timezone of the logs to a specific timezone</p>
-                </div>      
+                  <p className="text-xs text-muted-foreground leading-snug">Override the timezone used when parsing timestamps</p>
+                </div>
 
-                {/* Column 3: Year */}
-                <div className="space-y-1.5">
+                <div className="space-y-1.5 min-w-0 lg:col-span-2">
                   <Label htmlFor="force_start_year" className="text-sm font-medium">Force Year</Label>
-                  <Input 
+                  <Input
+                    id="force_start_year"
                     type="number"
                     aria-valuemin={1900}
                     aria-valuemax={2050}
-                    value={sessionOptionsYear || ''} 
+                    value={sessionOptionsYear || ''}
                     onChange={(e) => setSessionOptionYear(e.target.value)}
                     className="h-9"
                   />
-                  <p className="text-xs text-muted-foreground mt-1">Force the year of the logs to a specific year</p>
+                  <p className="text-xs text-muted-foreground leading-snug">Override year when logs omit it</p>
                 </div>
-                
-                {/* Column 4: Month */}
-                <div className="space-y-1.5">
+
+                <div className="space-y-1.5 min-w-0 lg:col-span-2">
                   <Label htmlFor="force_start_month" className="text-sm font-medium">Force Month</Label>
-                  <Select 
-                    value={sessionOptionsMonth || ''} 
+                  <Select
+                    value={sessionOptionsMonth || ''}
                     onValueChange={(value) => setSessionOptionMonth(value)}
                   >
                     <SelectTrigger id="force_start_month" className="h-9">
@@ -149,14 +145,13 @@ export const IngestSessionOptions: FC = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground mt-1">Force the month of the logs to a specific month</p>
+                  <p className="text-xs text-muted-foreground leading-snug">Override month when logs omit it</p>
                 </div>
-                
-                {/* Column 5: Day */}
-                <div className="space-y-1.5">
+
+                <div className="space-y-1.5 min-w-0 lg:col-span-2">
                   <Label htmlFor="force_start_day" className="text-sm font-medium">Force Day</Label>
-                  <Select 
-                    value={sessionOptionsDay || ''} 
+                  <Select
+                    value={sessionOptionsDay || ''}
                     onValueChange={(value) => setSessionOptionDay(value)}
                   >
                     <SelectTrigger id="force_start_day" className="h-9">
@@ -171,14 +166,12 @@ export const IngestSessionOptions: FC = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground mt-1">Force the day of the logs to a specific day</p>
+                  <p className="text-xs text-muted-foreground leading-snug">Override day when logs omit it</p>
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-6 gap-x-4 gap-y-0 items-end mt-4 pt-4 border-t">
-
-                {/* Multiline: enable */}
-                <div className="space-y-1.5 col-span-2">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-4 items-start mt-4 pt-4 border-t">
+                <div className="space-y-1.5 min-w-0 lg:col-span-3">
                   <Label htmlFor="multiline_enabled" className="text-sm font-medium">Multiline Records</Label>
                   <div className="h-9 flex items-center">
                     <Switch
@@ -196,11 +189,15 @@ export const IngestSessionOptions: FC = () => {
                       }}
                     />
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">Fold continuation lines (stack traces, wrapped entries) into the log statement they belong to</p>
+                  <p className="text-xs text-muted-foreground leading-snug">Fold continuation lines (stack traces, wrapped entries) into the log statement they belong to</p>
                 </div>
 
-                {/* Multiline: continuation style */}
-                <div className="space-y-1.5 col-span-2">
+                <div className={cn(
+                  'space-y-1.5 min-w-0',
+                  sessionOptionsMultilineEnabled && sessionOptionsMultilineMode === 'header'
+                    ? 'lg:col-span-4'
+                    : 'md:col-span-2 lg:col-span-9',
+                )}>
                   <Label htmlFor="multiline_preset" className="text-sm font-medium">Continuation Style</Label>
                   <Select
                     value={multilinePreset}
@@ -217,12 +214,11 @@ export const IngestSessionOptions: FC = () => {
                       <SelectItem value="custom">Custom regex</SelectItem>
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground mt-1">How to tell a new log statement from a continuation of the previous one</p>
+                  <p className="text-xs text-muted-foreground leading-snug">How to tell a new log statement from a continuation of the previous one</p>
                 </div>
 
-                {/* Multiline: custom header pattern */}
                 {sessionOptionsMultilineEnabled && sessionOptionsMultilineMode === 'header' && (
-                  <div className="space-y-1.5 col-span-2">
+                  <div className="space-y-1.5 min-w-0 md:col-span-2 lg:col-span-5">
                     <Label htmlFor="multiline_header_pattern" className="text-sm font-medium">New-record Pattern</Label>
                     <Input
                       id="multiline_header_pattern"
@@ -231,11 +227,10 @@ export const IngestSessionOptions: FC = () => {
                       placeholder={String.raw`e.g. ^\d{4}-\d{2}-\d{2}`}
                       className="h-9 font-mono text-sm"
                     />
-                    <p className="text-xs text-muted-foreground mt-1">Regex matching the start of a new log statement; every other line joins the previous one</p>
+                    <p className="text-xs text-muted-foreground leading-snug">Regex matching the start of a new log statement; every other line joins the previous one</p>
                   </div>
                 )}
               </div>
-
             </CardContent>
           </AccordionContent>
         </AccordionItem>

--- a/frontend/src/components/Import/UploadSteps/UploadingStep.tsx
+++ b/frontend/src/components/Import/UploadSteps/UploadingStep.tsx
@@ -9,7 +9,7 @@ const statusMeta = {
   failed:    { label: 'Failed',     fg: 'var(--ls-err)',    bg: 'var(--ls-err-soft)',  border: 'color-mix(in srgb, var(--ls-err) 25%, transparent)' },
 } as const;
 
-export const UploadingStep: FC = () => {
+export const UploadingStep: FC<{ onCancel: () => void }> = ({ onCancel }) => {
   const { files } = useImportStore();
 
   const { doneCount, totalCount, overallPct, linesProcessed } = useMemo(() => {
@@ -53,6 +53,23 @@ export const UploadingStep: FC = () => {
         <p style={{ fontSize: 12.5, color: 'var(--ls-text-2)' }}>
           {doneCount} / {totalCount} files complete · {linesProcessed.toLocaleString()} lines processed
         </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            marginTop: 10,
+            height: 30,
+            padding: '0 12px',
+            borderRadius: 6,
+            border: '1px solid var(--ls-border-strong)',
+            background: 'var(--ls-panel)',
+            color: 'var(--ls-text-2)',
+            fontSize: 12,
+            fontWeight: 500,
+          }}
+        >
+          Cancel import
+        </button>
       </div>
 
       {/* Overall progress bar */}

--- a/frontend/src/components/Import/hooks/useUpload.ts
+++ b/frontend/src/components/Import/hooks/useUpload.ts
@@ -1,14 +1,13 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useIngestEnd, useIngestLogs, useIngestStart } from '@/hooks/useApi';
 import { IngestSessionOptions } from '@/lib/api-types';
 import { sessionMultilineOption, useImportStore } from '@/stores/useImportStore';
-import type { ImportFile, UploadProgressHookResult } from '../types';
+import type { ImportFile, MultiFileUploadResult, UploadProgressHookResult } from '../types';
 import { LogSourceProviderService } from '../types';
 
 export const useUpload = (): UploadProgressHookResult => {
   const {
-    sessionID,
     isUploading,
     uploadProgress,
     approxLines,
@@ -19,114 +18,154 @@ export const useUpload = (): UploadProgressHookResult => {
   const ingestStartApi = useIngestStart();
   const ingestLogsApi = useIngestLogs();
   const ingestEndApi = useIngestEnd();
+  const activeAbortController = useRef<AbortController | null>(null);
+
+  useEffect(() => () => {
+    activeAbortController.current?.abort();
+  }, []);
 
   // --- Multi-file upload ---
   const handleMultiFileUpload = useCallback(async (
     importFiles: ImportFile[],
-    fileService: LogSourceProviderService
-  ): Promise<ImportFile[]> => {
+    fileService: LogSourceProviderService,
+  ): Promise<MultiFileUploadResult> => {
     setIsUploading(true);
     const results: ImportFile[] = [];
+    const abortController = new AbortController();
+    activeAbortController.current = abortController;
 
-    for (const importFile of importFiles) {
-      // Mark this file as uploading
-      updateFile(importFile.id, { uploadStatus: 'uploading', uploadProgress: 0 });
-
-      try {
-        // Step 1: Start ingest session for this file
-        // Per-file timestamp resolution: this file's own inference
-        // overlaid with this file's own overrides. Falls through to
-        // undefined when the file has no inference yet, in which case
-        // the backend re-derives defaults (legacy behaviour).
-        const fileTsConfig = importFile.timestampInference
-          ? { ...importFile.timestampInference.resolution, ...importFile.timestampOverrides }
-          : undefined;
-
-        const sessionOptions: IngestSessionOptions = {
-          pattern: importFile.selectedPattern?.pattern || '%{GREEDYDATA:message}',
-          name: importFile.selectedPattern?.name || 'Custom Pattern',
-          custom_patterns: importFile.selectedPattern?.custom_patterns || {},
-          priority: importFile.selectedPattern?.priority || 0,
-          source: importFile.fileName,
-          smart_decoder: importFile.sessionOptions.smartDecoder,
-          force_timezone: importFile.sessionOptions.timezone || undefined,
-          force_start_year: importFile.sessionOptions.year || undefined,
-          force_start_month: importFile.sessionOptions.month || undefined,
-          force_start_day: importFile.sessionOptions.day || undefined,
-          source_mtime: importFile.sourceMTime
-            ?? (importFile.file.lastModified ? new Date(importFile.file.lastModified).toISOString() : undefined),
-          timestamp_config: fileTsConfig,
-          meta: { _src: `file.${importFile.fileName}` },
-          multiline: sessionMultilineOption(useImportStore.getState()),
-        };
-
-        const startResponse = await ingestStartApi.execute(sessionOptions);
-        if (startResponse.status !== 'success' || !startResponse.session_id) {
-          throw new Error('Failed to start ingestion session');
+    try {
+      for (const importFile of importFiles) {
+        if (abortController.signal.aborted) {
+          updateFile(importFile.id, {
+            uploadStatus: 'failed',
+            uploadError: 'Import cancelled',
+          });
+          results.push({ ...importFile, uploadStatus: 'failed', uploadError: 'Import cancelled' });
+          continue;
         }
 
-        const currentSessionID = startResponse.session_id;
-        let handledLines = 0;
+        // Mark this file as uploading
+        updateFile(importFile.id, { uploadStatus: 'uploading', uploadProgress: 0 });
 
-        // Step 2: Stream file chunks
-        await fileService.handleFileImport(importFile.file, 10000, async (lines, totalLines, next) => {
-          const requestBody = {
-            logs: lines,
-            session_id: currentSessionID,
+        let currentSessionID: string | undefined;
+        try {
+          // Step 1: Start ingest session for this file
+          // Per-file timestamp resolution: this file's own inference
+          // overlaid with this file's own overrides. Falls through to
+          // undefined when the file has no inference yet, in which case
+          // the backend re-derives defaults (legacy behaviour).
+          const fileTsConfig = importFile.timestampInference
+            ? { ...importFile.timestampInference.resolution, ...importFile.timestampOverrides }
+            : undefined;
+
+          const sessionOptions: IngestSessionOptions = {
+            pattern: importFile.selectedPattern?.pattern || '%{GREEDYDATA:message}',
+            name: importFile.selectedPattern?.name || 'Custom Pattern',
+            custom_patterns: importFile.selectedPattern?.custom_patterns || {},
+            priority: importFile.selectedPattern?.priority || 0,
+            source: importFile.fileName,
+            smart_decoder: importFile.sessionOptions.smartDecoder,
+            force_timezone: importFile.sessionOptions.timezone || undefined,
+            force_start_year: importFile.sessionOptions.year || undefined,
+            force_start_month: importFile.sessionOptions.month || undefined,
+            force_start_day: importFile.sessionOptions.day || undefined,
+            source_mtime: importFile.sourceMTime
+              ?? (importFile.file.lastModified ? new Date(importFile.file.lastModified).toISOString() : undefined),
+            timestamp_config: fileTsConfig,
+            meta: { _src: `file.${importFile.fileName}` },
+            multiline: sessionMultilineOption(useImportStore.getState()),
           };
 
-          const response = await ingestLogsApi.execute(requestBody);
-          if (response.status !== 'success') {
-            throw new Error(`Failed to ingest chunk`);
+          const startResponse = await ingestStartApi.execute(sessionOptions, abortController.signal);
+          if (startResponse.status !== 'success' || !startResponse.session_id) {
+            throw new Error('Failed to start ingestion session');
           }
 
-          handledLines += lines.length;
-          const progress = Math.ceil((handledLines / totalLines) * 100);
-          updateFile(importFile.id, { uploadProgress: progress, totalLinesProcessed: handledLines });
-          next();
-        });
+          currentSessionID = startResponse.session_id;
+          let handledLines = 0;
 
-        // Step 3: End session
-        await ingestEndApi.execute(currentSessionID);
+          // Step 2: Stream file chunks. The reader invokes the callback only
+          // after the previous request resolves, keeping memory bounded and
+          // preserving source order.
+          await fileService.handleFileImport(importFile.file, 10000, async ({ lines, bytesRead, totalBytes }) => {
+            const requestBody = {
+              logs: lines,
+              session_id: currentSessionID,
+            };
 
-        updateFile(importFile.id, {
-          uploadStatus: 'success',
-          uploadProgress: 100,
-          totalLinesProcessed: handledLines,
-        });
+            const response = await ingestLogsApi.execute(requestBody, abortController.signal);
+            if (response.status !== 'success') {
+              throw new Error('Failed to ingest chunk');
+            }
 
-        results.push({ ...importFile, uploadStatus: 'success', totalLinesProcessed: handledLines });
-      } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : 'Upload failed';
-        updateFile(importFile.id, {
-          uploadStatus: 'failed',
-          uploadError: errorMsg,
-        });
-        results.push({ ...importFile, uploadStatus: 'failed', uploadError: errorMsg });
+            handledLines += lines.length;
+            const progress = totalBytes > 0
+              ? Math.min(99, Math.floor((bytesRead / totalBytes) * 100))
+              : 0;
+            updateFile(importFile.id, { uploadProgress: progress, totalLinesProcessed: handledLines });
+          }, abortController.signal);
 
-        // Try to clean up the session
-        try {
-          if (sessionID) await ingestEndApi.execute(sessionID);
-        } catch { /* ignore cleanup error */ }
+          // Step 3: End session. Cleanup is repeated in finally only when
+          // this call itself fails, because /ingest/end is idempotent.
+          await ingestEndApi.execute(currentSessionID);
+          currentSessionID = undefined;
+
+          updateFile(importFile.id, {
+            uploadStatus: 'success',
+            uploadProgress: 100,
+            totalLinesProcessed: handledLines,
+          });
+
+          results.push({ ...importFile, uploadStatus: 'success', totalLinesProcessed: handledLines });
+        } catch (error) {
+          const errorMsg = abortController.signal.aborted
+            ? 'Import cancelled'
+            : error instanceof Error ? error.message : 'Upload failed';
+          updateFile(importFile.id, {
+            uploadStatus: 'failed',
+            uploadError: errorMsg,
+          });
+          results.push({ ...importFile, uploadStatus: 'failed', uploadError: errorMsg });
+        } finally {
+          // Always close the session created for this file, including when
+          // reading, upload, decoding, or storage fails.
+          if (currentSessionID) {
+            try {
+              await ingestEndApi.execute(currentSessionID);
+            } catch {
+              // The original failure is more useful to the caller. The
+              // backend's cleanup sweeper handles an unavailable end call.
+            }
+          }
+        }
       }
+    } finally {
+      if (activeAbortController.current === abortController) {
+        activeAbortController.current = null;
+      }
+      setIsUploading(false);
     }
 
-    setIsUploading(false);
-    return results;
+    return { files: results, cancelled: abortController.signal.aborted };
   }, [
     updateFile,
     setIsUploading,
     ingestStartApi,
     ingestLogsApi,
     ingestEndApi,
-    sessionID,
   ]);
+
+  const cancelUpload = useCallback(() => {
+    activeAbortController.current?.abort();
+  }, []);
 
   return {
     isUploading,
     uploadProgress,
     approxLines,
     handleMultiFileUpload,
+    cancelUpload,
   };
 };
 

--- a/frontend/src/components/Import/types/index.ts
+++ b/frontend/src/components/Import/types/index.ts
@@ -88,11 +88,17 @@ export interface UploadProgressHookProps {
   detectionResult?: DetectionResult;
 }
 
+export interface MultiFileUploadResult {
+  files: ImportFile[];
+  cancelled: boolean;
+}
+
 export interface UploadProgressHookResult {
   isUploading: boolean;
   uploadProgress: number;
   approxLines: number;
-  handleMultiFileUpload: (files: ImportFile[], fileService: LogSourceProviderService) => Promise<ImportFile[]>;
+  handleMultiFileUpload: (files: ImportFile[], fileService: LogSourceProviderService) => Promise<MultiFileUploadResult>;
+  cancelUpload: () => void;
 }
 
 export interface FileParserHookResult {
@@ -147,6 +153,17 @@ export interface LogSourceProvider {
 export interface LogSourceProviderService {
   name: string;
   // Start the actual import process
-  handleFileImport: (filehandle: object, chunkSize: number, callback: (lines: string[], totalLines: number, next: () => void) => Promise<void>) => Promise<void>;
+  handleFileImport: (
+    filehandle: object,
+    chunkSize: number,
+    callback: (chunk: FileImportChunk) => Promise<void>,
+    signal?: AbortSignal,
+  ) => Promise<void>;
   handleFilePreview: (filehandle: object, onPreviewReadyCallback: (lines: string[]) => void) => Promise<void>;
-} 
+}
+
+export interface FileImportChunk {
+  lines: string[];
+  bytesRead: number;
+  totalBytes: number;
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -33,7 +33,8 @@ async function apiRequest<T = unknown>(
   endpoint: string,
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' = 'GET',
   body?: any,
-  params?: Record<string, string | number | boolean | undefined> | LogQueryParams
+  params?: Record<string, string | number | boolean | undefined> | LogQueryParams,
+  signal?: AbortSignal,
 ): Promise<T> {
   // Build URL with query parameters if provided
   let url = `${API_BASE_URL}${endpoint}`;
@@ -55,6 +56,7 @@ async function apiRequest<T = unknown>(
   // Configure request options
   const options: RequestInit = {
     method,
+    signal,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -113,17 +115,17 @@ export async function deleteGrokPattern(name: string): Promise<GrokPatternRespon
   return apiRequest<GrokPatternResponse>('/grok', 'DELETE', undefined, { name });
 }
 
-export async function ingestStart(request: IngestSessionOptions): Promise<IngestResponse> {
-  return apiRequest<IngestResponse>('/ingest/start', 'POST', request);
+export async function ingestStart(request: IngestSessionOptions, signal?: AbortSignal): Promise<IngestResponse> {
+  return apiRequest<IngestResponse>('/ingest/start', 'POST', request, undefined, signal);
 }
 
-export async function ingestEnd(sessionId?: string): Promise<IngestResponse> {
+export async function ingestEnd(sessionId?: string, signal?: AbortSignal): Promise<IngestResponse> {
   const request = sessionId ? { session_id: sessionId } : {};
-  return apiRequest<IngestResponse>('/ingest/end', 'POST', request);
+  return apiRequest<IngestResponse>('/ingest/end', 'POST', request, undefined, signal);
 }
 
-export async function ingestLogs(request: IngestRequest): Promise<IngestResponse> {
-  return apiRequest<IngestResponse>('/ingest/logs', 'POST', request);
+export async function ingestLogs(request: IngestRequest, signal?: AbortSignal): Promise<IngestResponse> {
+  return apiRequest<IngestResponse>('/ingest/logs', 'POST', request, undefined, signal);
 }
 
 export async function ingestFile(request: IngestFileRequest): Promise<IngestResponse> {

--- a/frontend/src/lib/workspace-utils.ts
+++ b/frontend/src/lib/workspace-utils.ts
@@ -1,0 +1,20 @@
+// Keep saved column widths within the backend workspace schema's bounds.
+export const MAX_WORKSPACE_COLUMN_WIDTH = 2000;
+
+export const normalizeWorkspaceColumnWidths = (
+  widths?: Record<string, unknown> | null,
+): Record<string, number> => {
+  const normalized: Record<string, number> = {};
+
+  for (const [column, width] of Object.entries(widths ?? {})) {
+    const numericWidth = typeof width === 'number' ? width : Number(width);
+    if (!Number.isFinite(numericWidth)) continue;
+
+    normalized[column] = Math.min(
+      MAX_WORKSPACE_COLUMN_WIDTH,
+      Math.max(0, Math.round(numericWidth)),
+    );
+  }
+
+  return normalized;
+};

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -39,6 +39,7 @@ const Import: FC = () => {
 
   const {
     handleMultiFileUpload,
+    cancelUpload,
   } = useUpload();
 
   const fileService = useFileSelectionService();
@@ -171,7 +172,7 @@ const Import: FC = () => {
         );
       case 2:
         if (isUploading) {
-          return <UploadingStep />;
+          return <UploadingStep onCancel={cancelUpload} />;
         }
         return (
           <FileAnalyzingStep
@@ -206,11 +207,19 @@ const Import: FC = () => {
         description: `Importing ${files.length} file${files.length !== 1 ? 's' : ''}...`,
       });
 
-      await handleMultiFileUpload(files, fileService);
+      const { cancelled } = await handleMultiFileUpload(files, fileService);
 
       const updatedFiles = useImportStore.getState().files;
       const successCount = updatedFiles.filter(f => f.uploadStatus === 'success').length;
       const failedCount = updatedFiles.filter(f => f.uploadStatus === 'failed').length;
+
+      if (cancelled && successCount === 0) {
+        toast({
+          title: "Import cancelled",
+          description: "No files were imported.",
+        });
+        return;
+      }
 
       if (successCount > 0) {
         toast({

--- a/frontend/src/stores/__tests__/useSearchQueryParams.test.ts
+++ b/frontend/src/stores/__tests__/useSearchQueryParams.test.ts
@@ -225,6 +225,19 @@ describe("column management", () => {
     expect(state.columnWidths["message"]).toBe(300);
   });
 
+  it("keeps column widths within the workspace API limits", () => {
+    useSearchQueryParamsStore.getState().setColumnWidths({
+      program: 2400,
+      message: -20,
+      invalid: Number.NaN,
+    });
+
+    expect(useSearchQueryParamsStore.getState().columnWidths).toEqual({
+      program: 2000,
+      message: 0,
+    });
+  });
+
   it("setColumnLocked toggles lock state", () => {
     useSearchQueryParamsStore.getState().setColumnLocked(true);
     expect(useSearchQueryParamsStore.getState().isColumnLocked).toBe(true);

--- a/frontend/src/stores/__tests__/useWorkspaceStore.test.ts
+++ b/frontend/src/stores/__tests__/useWorkspaceStore.test.ts
@@ -51,6 +51,22 @@ describe('workspace state mapping', () => {
     expect(workspace.color_rules).toHaveLength(1);
   });
 
+  it('clamps oversized persisted column widths before saving', () => {
+    const search = useSearchQueryParamsStore.getState();
+    search.setSelectedColumns(['timestamp', 'program']);
+    // Hydrated Zustand state can predate the normalization boundary.
+    useSearchQueryParamsStore.setState({ columnWidths: { program: 2400 } });
+
+    const workspace = buildWorkspaceFromState(
+      'Program view',
+      '',
+      useSearchQueryParamsStore.getState(),
+      useColorRuleStore.getState().colorRules,
+    );
+
+    expect(workspace.column_widths).toEqual({ program: 2000 });
+  });
+
   it('applies a workspace to search state and color rules', () => {
     const workspace: Workspace = {
       id: 'workspace-1',

--- a/frontend/src/stores/useSearchQueryParams.ts
+++ b/frontend/src/stores/useSearchQueryParams.ts
@@ -1,4 +1,5 @@
 import { calculatePresetRelativeDate, calculateRelativeDate, calculateRelativeDateRange, RELATIVE_DATE_PRESETS } from '@/lib/date-utils';
+import { normalizeWorkspaceColumnWidths } from '@/lib/workspace-utils';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
@@ -467,18 +468,19 @@ export const useSearchQueryParamsStore = create<SearchQueryParamsStoreState>()(
           set({ selectedColumns: newSelectedColumns });
         },
         setColumnWidths: (columnWidths) => {
-          set({ columnWidths });
+          set({ columnWidths: normalizeWorkspaceColumnWidths(columnWidths) });
         },
         setColumnLocked: (columnLocked) => {
           set({ isColumnLocked: columnLocked });
         },
         updateColumnWidth: (column, width) => {
           const currentState = get();
+          const columnWidths = normalizeWorkspaceColumnWidths({
+            ...currentState.columnWidths,
+            [column]: width,
+          });
           set({ 
-            columnWidths: { 
-              ...currentState.columnWidths, 
-              [column]: width 
-            } 
+            columnWidths,
           });
         },
         resetPagination: () => {

--- a/frontend/src/stores/useWorkspaceStore.ts
+++ b/frontend/src/stores/useWorkspaceStore.ts
@@ -12,6 +12,7 @@ import {
   updateWorkspace,
 } from '@/lib/api-client';
 import { calculateRelativeDateRange } from '@/lib/date-utils';
+import { normalizeWorkspaceColumnWidths } from '@/lib/workspace-utils';
 import { useColorRuleStore } from '@/stores/useColorRuleStore';
 import {
   SearchQueryParamsStoreState,
@@ -66,7 +67,7 @@ export const buildWorkspaceFromState = (
   sort_by: search.sortBy,
   sort_order: search.sortOrder === 'asc' ? 'asc' : 'desc',
   columns: [...search.selectedColumns],
-  column_widths: { ...search.columnWidths },
+  column_widths: normalizeWorkspaceColumnWidths(search.columnWidths),
   color_rules: colorRules.map(toWorkspaceColorRule),
   facet_fields: existing?.facet_fields ? [...existing.facet_fields] : [],
   visualization: existing?.visualization ?? { type: 'logs', bucket: 'auto' },
@@ -93,7 +94,7 @@ export const applyWorkspaceToCurrentState = (workspace: Workspace) => {
       workspace.columns && workspace.columns.length > 0
         ? workspace.columns
         : search.selectedColumns,
-    columnWidths: workspace.column_widths ?? {},
+    columnWidths: normalizeWorkspaceColumnWidths(workspace.column_widths),
     currentPage: 1,
     ...timeState,
   });


### PR DESCRIPTION
## Summary

- Add byte-range preview and streaming chunked file import with UTF-8/CRLF handling, physical-line and serialized-request limits, and a 5 GiB file-selection ceiling.
- Add sequential, abortable multi-file uploads with visible cancellation, byte progress, per-file session cleanup, and activity-based session expiry.
- Enforce backend request, line-count, and line-size limits with stable 413 error codes; regenerate Swagger documentation.
- Add the production-readiness plan and focused frontend/backend regression coverage.

## Validation

- `npm test` — 173 tests passed
- `npm run build` — passed
- `go test ./...` — passed
- `go test -race ./pkg/storage ./pkg/server/...` — passed
- `git diff --check` — passed